### PR TITLE
[ucssession] fixed forceflag and validate connection method

### DIFF
--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -408,8 +408,9 @@ class UcsSession(object):
                                             dn=top_system.dn)
                 response = self.post_elem(elem)
                 if response.error_code != 0:
-                    raise UcsException(response.error_code,
-                                       response.error_descr)
+                    # raise UcsException(response.error_code,
+                    #                    response.error_descr)
+                    return False
                 return True
             else:
                 self._logout()
@@ -436,6 +437,8 @@ class UcsSession(object):
         from ucsmethodfactory import aaa_login
         from ucsmethodfactory import config_resolve_class
         from ucsmethodfactory import config_resolve_dn
+
+        self.__force = force
 
         if self.__validate_connection():
             return True

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -408,8 +408,6 @@ class UcsSession(object):
                                             dn=top_system.dn)
                 response = self.post_elem(elem)
                 if response.error_code != 0:
-                    # raise UcsException(response.error_code,
-                    #                    response.error_descr)
                     return False
                 return True
             else:


### PR DESCRIPTION
Validate connection method should return a boolean. Instead of raising an exception in case of connection failure, it should return False now.
The force flag is now used to force a re-connection to the server