### PR TITLE
Support for Comparing and Syncing Managed Objects across Ucs Domains

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/utils/test_comparesync.py
+++ b/tests/utils/test_comparesync.py
@@ -11,13 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import with_setup
+from nose.tools import *
 from ..connection.info import custom_setup, custom_teardown
 
 from ucsmsdk.utils.comparesyncmo import compare_ucs_mo, write_mo_diff
 
-
-handle = None
 ref_handle = None
 diff_handle = None
 
@@ -29,11 +27,8 @@ def static_setup():
     global ref_handle
     global diff_handle
 
-    ref_ip = "192.168.1.1"
-    diff_ip = "192.168.1.2"
-
-    ref_handle = UcsHandle(ref_ip, "admin", "password")
-    diff_handle = UcsHandle(diff_ip, "admin", "password")
+    ref_handle = UcsHandle("192.168.1.1", "admin", "password")
+    diff_handle = UcsHandle("192.168.1.2", "admin", "password")
 
     ref_handle.__dict__['_UcsSession__version'] = UcsVersion("2.2(5a)")
     diff_handle.__dict__['_UcsSession__version'] = UcsVersion("2.2(2c)")
@@ -43,32 +38,40 @@ def test_compare_same_obj_with_diff_props():
     from ucsmsdk.mometa.ls.LsServer import LsServer
     static_setup()
 
-    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")]
-    ref_mos[0].__dict__['config_state'] = "applied"
-    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="same",
-                         usr_lbl="xxx")]
-    diff_mos[0].__dict__['config_state'] = "applying"
+    ref_mo = LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")
+    ref_mo.__dict__['config_state'] = "applied"
+    ref_mo._handle = ref_handle
+    ref_mos = [ref_mo]
 
-    difference = compare_ucs_mo(ref_handle, ref_mos,
-                                diff_handle, diff_mos,
-                                include_operational=False)
+    diff_mo = LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="xxx")
+    diff_mo.__dict__['config_state'] = "applying"
+    diff_mo._handle = diff_handle
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos)
     write_mo_diff(difference)
+    assert_equal(len(difference), 1)
+    assert_equal(len(difference[0].diff_property), 1)
 
 
 def test_compare_same_obj_with_diff_props_include_operational():
     from ucsmsdk.mometa.ls.LsServer import LsServer
     static_setup()
 
-    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")]
-    ref_mos[0].__dict__['config_state'] = "applied"
-    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="same",
-                         usr_lbl="xxx")]
-    diff_mos[0].__dict__['config_state'] = "applying"
+    ref_mo = LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")
+    ref_mo.__dict__['config_state'] = "applied"
+    ref_mo._handle = ref_handle
+    ref_mos = [ref_mo]
 
-    difference = compare_ucs_mo(ref_handle, ref_mos,
-                                diff_handle, diff_mos,
-                                include_operational=True)
+    diff_mo = LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="xxx")
+    diff_mo.__dict__['config_state'] = "applying"
+    diff_mo._handle = diff_handle
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos, include_operational=True)
     write_mo_diff(difference)
+    assert_equal(len(difference), 1)
+    assert_equal(len(difference[0].diff_property), 2)
 
 
 def test_compare_add_obj_to_ref_exist_only_in_diff():
@@ -76,27 +79,31 @@ def test_compare_add_obj_to_ref_exist_only_in_diff():
     static_setup()
 
     ref_mos = []
-    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="add_to_ref",
-                         usr_lbl="xxx")]
 
-    difference = compare_ucs_mo(ref_handle, ref_mos,
-                                diff_handle, diff_mos,
-                                include_operational=False)
+    diff_mo = LsServer(parent_mo_or_dn="org-root", name="add_to_ref",
+                       usr_lbl="xxx")
+    diff_mo._handle = diff_handle
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos)
     write_mo_diff(difference)
+    assert_equal(len(difference), 1)
 
 
 def test_compare_remove_obj_from_ref_exist_only_in_ref():
     from ucsmsdk.mometa.ls.LsServer import LsServer
     static_setup()
 
-    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="remove_from_ref",
-                        usr_lbl="")]
+    ref_mo = LsServer(parent_mo_or_dn="org-root", name="remove_from_ref",
+                      usr_lbl="")
+    ref_mo._handle = ref_handle
+    ref_mos = [ref_mo]
+
     diff_mos = []
 
-    difference = compare_ucs_mo(ref_handle, ref_mos,
-                                diff_handle, diff_mos,
-                                include_operational=False)
+    difference = compare_ucs_mo(ref_mos, diff_mos)
     write_mo_diff(difference)
+    assert_equal(len(difference), 1)
 
 
 def test_compare_org_hierarchy():
@@ -105,17 +112,103 @@ def test_compare_org_hierarchy():
     static_setup()
 
     ref_org = OrgOrg(parent_mo_or_dn="org-root", name="org_same", descr="")
+    ref_org._handle = ref_handle
     ref_same_sp = LsServer(ref_org, name="same")
+    ref_same_sp._handle = ref_handle
     ref_remove = LsServer(ref_org, name="remove_from_ref")
+    ref_remove._handle = ref_handle
     ref_mos = [ref_org, ref_same_sp, ref_remove]
 
     diff_org = OrgOrg(parent_mo_or_dn="org-root", name="org_same",
                       descr="diff")
+    diff_org._handle = diff_handle
     diff_same_sp = LsServer(diff_org, name="same", usr_lbl="diff")
+    diff_same_sp._handle = diff_handle
     diff_add = LsServer(diff_org, name="add_to_ref")
+    diff_add._handle = diff_handle
     diff_mos = [diff_org, diff_same_sp, diff_add]
 
-    difference = compare_ucs_mo(ref_handle, ref_mos,
-                                diff_handle, diff_mos,
-                                include_operational=False)
+    difference = compare_ucs_mo(ref_mos, diff_mos)
     write_mo_diff(difference)
+    assert_equal(len(difference), 4)
+
+
+def test_unknown_property():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mo = LsServer(parent_mo_or_dn="org-root", name="ra_ref", usr_lbl="")
+    ref_mo._handle = ref_handle
+    ref_mo.unknown = ""
+    ref_mos = [ref_mo]
+
+    diff_mo = LsServer(parent_mo_or_dn="org-root", name="ra_ref",
+                       usr_lbl="xxx")
+    diff_mo._handle = diff_handle
+    diff_mo.unknown = "yyy"
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos)
+    write_mo_diff(difference)
+    assert_equal(len(difference), 1)
+    assert_equal(len(difference[0].diff_property), 1)
+
+
+def test_unknown_property_noversionfilter():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mo = LsServer(parent_mo_or_dn="org-root", name="ra_ref", usr_lbl="")
+    ref_mo._handle = ref_handle
+    ref_mo.unknown = ""
+    ref_mos = [ref_mo]
+
+    diff_mo = LsServer(parent_mo_or_dn="org-root", name="ra_ref",
+                       usr_lbl="xxx")
+    diff_mo._handle = diff_handle
+    diff_mo.unknown = "yyy"
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos, no_version_filter=True)
+    write_mo_diff(difference)
+    assert_equal(len(difference), 1)
+    assert_equal(len(difference[0].diff_property), 2)
+
+
+def test_unknown_mo():
+    from ucsmsdk.ucsmo import GenericMo
+    static_setup()
+
+    ref_mo = GenericMo(class_id="unknown", parent_mo_or_dn="parent_dn",
+                       dn="sys/unknown", unknown="")
+    ref_mo._handle = ref_handle
+    ref_mos = [ref_mo]
+
+    diff_mo = GenericMo(class_id="unknown", parent_mo_or_dn="parent_dn",
+                        dn="sys/unknown", unknown="yyy")
+    diff_mo._handle = diff_handle
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos)
+    write_mo_diff(difference)
+    assert_equal(len(difference), 0)
+
+
+def test_unknown_mo_noversionfilter():
+    from ucsmsdk.ucsmo import GenericMo
+    static_setup()
+
+    ref_mo = GenericMo(class_id="unknown", parent_mo_or_dn="parent_dn",
+                       dn="sys/unknown", unknown="")
+    ref_mo._handle = ref_handle
+    ref_mos = [ref_mo]
+
+    diff_mo = GenericMo(class_id="unknown", parent_mo_or_dn="parent_dn",
+                        dn="sys/unknown", unknown="yyy")
+    diff_mo._handle = diff_handle
+    diff_mos = [diff_mo]
+
+    difference = compare_ucs_mo(ref_mos, diff_mos, no_version_filter=True)
+    write_mo_diff(difference)
+    assert_equal(len(difference), 1)
+    assert_equal(len(difference[0].diff_property), 1)

--- a/tests/utils/test_comparesync.py
+++ b/tests/utils/test_comparesync.py
@@ -169,7 +169,7 @@ def test_unknown_property_noversionfilter():
     diff_mo.unknown = "yyy"
     diff_mos = [diff_mo]
 
-    difference = compare_ucs_mo(ref_mos, diff_mos, no_version_filter=True)
+    difference = compare_ucs_mo(ref_mos, diff_mos, version_filter=False)
     write_mo_diff(difference)
     assert_equal(len(difference), 1)
     assert_equal(len(difference[0].diff_property), 2)
@@ -208,7 +208,7 @@ def test_unknown_mo_noversionfilter():
     diff_mo._handle = diff_handle
     diff_mos = [diff_mo]
 
-    difference = compare_ucs_mo(ref_mos, diff_mos, no_version_filter=True)
+    difference = compare_ucs_mo(ref_mos, diff_mos, version_filter=False)
     write_mo_diff(difference)
     assert_equal(len(difference), 1)
     assert_equal(len(difference[0].diff_property), 1)

--- a/tests/utils/test_comparesync.py
+++ b/tests/utils/test_comparesync.py
@@ -1,0 +1,121 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nose.tools import with_setup
+from ..connection.info import custom_setup, custom_teardown
+
+from ucsmsdk.utils.comparesyncmo import compare_ucs_mo, write_mo_diff
+
+
+handle = None
+ref_handle = None
+diff_handle = None
+
+
+def static_setup():
+    from ucsmsdk.ucshandle import UcsHandle
+    from ucsmsdk.ucscoremeta import UcsVersion
+
+    global ref_handle
+    global diff_handle
+
+    ref_ip = "192.168.1.1"
+    diff_ip = "192.168.1.2"
+
+    ref_handle = UcsHandle(ref_ip, "admin", "password")
+    diff_handle = UcsHandle(diff_ip, "admin", "password")
+
+    ref_handle.__dict__['_UcsSession__version'] = UcsVersion("2.2(5a)")
+    diff_handle.__dict__['_UcsSession__version'] = UcsVersion("2.2(2c)")
+
+
+def test_compare_same_obj_with_diff_props():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")]
+    ref_mos[0].__dict__['config_state'] = "applied"
+    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="same",
+                         usr_lbl="xxx")]
+    diff_mos[0].__dict__['config_state'] = "applying"
+
+    difference = compare_ucs_mo(ref_handle, ref_mos,
+                                diff_handle, diff_mos,
+                                include_operational=False)
+    write_mo_diff(difference)
+
+
+def test_compare_same_obj_with_diff_props_include_operational():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="same", usr_lbl="")]
+    ref_mos[0].__dict__['config_state'] = "applied"
+    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="same",
+                         usr_lbl="xxx")]
+    diff_mos[0].__dict__['config_state'] = "applying"
+
+    difference = compare_ucs_mo(ref_handle, ref_mos,
+                                diff_handle, diff_mos,
+                                include_operational=True)
+    write_mo_diff(difference)
+
+
+def test_compare_add_obj_to_ref_exist_only_in_diff():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mos = []
+    diff_mos = [LsServer(parent_mo_or_dn="org-root", name="add_to_ref",
+                         usr_lbl="xxx")]
+
+    difference = compare_ucs_mo(ref_handle, ref_mos,
+                                diff_handle, diff_mos,
+                                include_operational=False)
+    write_mo_diff(difference)
+
+
+def test_compare_remove_obj_from_ref_exist_only_in_ref():
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_mos = [LsServer(parent_mo_or_dn="org-root", name="remove_from_ref",
+                        usr_lbl="")]
+    diff_mos = []
+
+    difference = compare_ucs_mo(ref_handle, ref_mos,
+                                diff_handle, diff_mos,
+                                include_operational=False)
+    write_mo_diff(difference)
+
+
+def test_compare_org_hierarchy():
+    from ucsmsdk.mometa.org.OrgOrg import OrgOrg
+    from ucsmsdk.mometa.ls.LsServer import LsServer
+    static_setup()
+
+    ref_org = OrgOrg(parent_mo_or_dn="org-root", name="org_same", descr="")
+    ref_same_sp = LsServer(ref_org, name="same")
+    ref_remove = LsServer(ref_org, name="remove_from_ref")
+    ref_mos = [ref_org, ref_same_sp, ref_remove]
+
+    diff_org = OrgOrg(parent_mo_or_dn="org-root", name="org_same",
+                      descr="diff")
+    diff_same_sp = LsServer(diff_org, name="same", usr_lbl="diff")
+    diff_add = LsServer(diff_org, name="add_to_ref")
+    diff_mos = [diff_org, diff_same_sp, diff_add]
+
+    difference = compare_ucs_mo(ref_handle, ref_mos,
+                                diff_handle, diff_mos,
+                                include_operational=False)
+    write_mo_diff(difference)

--- a/ucsmsdk/ucscore.py
+++ b/ucsmsdk/ucscore.py
@@ -39,6 +39,7 @@ class UcsBase(object):
     def __init__(self, class_id):
         self._class_id = class_id
         self._child = []
+        self._handle = None
 
     @property
     def child(self):
@@ -52,6 +53,9 @@ class UcsBase(object):
 
     def get_class_id(self):
         return self._class_id
+
+    def get_handle(self):
+        return self._handle
 
     def child_add(self, obj):
         """Method adds the child managed object."""
@@ -177,9 +181,11 @@ class BaseObject(UcsBase):
         self.child_to_xml(xml_obj, option)
         return xml_obj
 
-    def from_xml(self, elem):
+    def from_xml(self, elem, handle=None):
         """This method creates the object from the xml representation
         of the Method object."""
+
+        self._handle = handle
         if elem.attrib:
             for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
                 self.attr_set(ucsgenutils.convert_to_python_var_name(attr_name)
@@ -194,4 +200,4 @@ class BaseObject(UcsBase):
                 cln = ucsgenutils.word_u(child_elem.tag)
                 child = ucscoreutils.get_ucs_obj(cln, child_elem)
                 self._child.append(child)
-                child.from_xml(child_elem)
+                child.from_xml(child_elem, handle)

--- a/ucsmsdk/ucsmethod.py
+++ b/ucsmsdk/ucsmethod.py
@@ -120,9 +120,11 @@ class ExternalMethod(UcsBase):
         self.child_to_xml(xml_obj, option)
         return xml_obj
 
-    def from_xml(self, elem):  # , handle, modify_self=False, mo=None):
+    def from_xml(self, elem, handle=None):  # , handle, modify_self=False, mo=None):
         """Method updates/fills the object from the xml representation
         of the external method object. """
+		
+        self._handle = handle
         if elem.attrib:
             for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
                 if attr_name in self.__property_map:
@@ -156,8 +158,7 @@ class ExternalMethod(UcsBase):
                             self.set_attr(child_name,
                                           child_obj)
                             # print child_method_obj.__dict__
-                            child_obj.from_xml(
-                                child_elem)
+                            child_obj.from_xml(child_elem, handle)
 
     def __str__(self):
         tab_size = 8

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -55,7 +55,7 @@ class ManagedObject(UcsBase):
 
     DUMMY_DIRTY = "0x1L"
     __internal_prop = frozenset(
-        ["_dirty_mask", "_class_id", "_child", ''])
+        ["_dirty_mask", "_class_id", "_child", "_handle", ''])
 
     def __init__(self, class_id, parent_mo_or_dn=None, **kwargs):
         self.__parent_mo = None
@@ -538,7 +538,7 @@ class GenericMo(UcsBase):
         if elem is None:
             return None
 
-        self._class_id = handle
+        self._handle = handle
         self._class_id = elem.tag
         if elem.attrib:
             for name, value in ucsgenutils.iteritems(elem.attrib):

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -320,12 +320,13 @@ class ManagedObject(UcsBase):
         self.child_to_xml(xml_obj, option)
         return xml_obj
 
-    def from_xml(self, elem):
+    def from_xml(self, elem, handle=None):
         """
         Method updates the object from the xml representation of the managed
         object.
         """
 
+        self._handle = handle
         if elem.attrib:
             if self.__class__.__name__ != "ManagedObject":
                 for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
@@ -357,7 +358,7 @@ class ManagedObject(UcsBase):
                 child_obj = ucscoreutils.get_ucs_obj(class_id, child_elem,
                                                      self)
                 self.child_add(child_obj)
-                child_obj.from_xml(child_elem)
+                child_obj.from_xml(child_elem, handle)
 
     def sync_mo(self, mo):
         """
@@ -517,7 +518,7 @@ class GenericMo(UcsBase):
         """Getter Method of GenericMO Class"""
         return self.__properties
 
-    def from_xml(self, elem):
+    def from_xml(self, elem, handle=None):
         """
         This method is form objects out of xml element.
         This is called internally from ucsxmlcode.from_xml_str
@@ -537,6 +538,7 @@ class GenericMo(UcsBase):
         if elem is None:
             return None
 
+        self._class_id = handle
         self._class_id = elem.tag
         if elem.attrib:
             for name, value in ucsgenutils.iteritems(elem.attrib):
@@ -570,7 +572,7 @@ class GenericMo(UcsBase):
                     pdn = self.dn
                 child_obj = GenericMo(class_id, parent_mo_or_dn=pdn)
                 self.child_add(child_obj)
-                child_obj.from_xml(child)
+                child_obj.from_xml(child, handle)
 
     def __get_mo_obj(self, class_id):
         """

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -269,7 +269,7 @@ class UcsSession(object):
             log.debug('%s <==== %s' % (self.__uri, response_str))
 
         if response_str:
-            response = xc.from_xml_str(response_str)
+            response = xc.from_xml_str(response_str, self)
             return response
 
         return None

--- a/ucsmsdk/ucsxmlcodec.py
+++ b/ucsmsdk/ucsxmlcodec.py
@@ -63,7 +63,7 @@ def extract_root_elem(xml_str):
     return root_elem
 
 
-def from_xml_str(xml_str):
+def from_xml_str(xml_str, handle=None):
     """
     Generates response object from the given xml string.
 
@@ -89,5 +89,5 @@ def from_xml_str(xml_str):
 
     class_id = ucsgenutils.word_u(root_elem.tag)
     response = ucscoreutils.get_ucs_obj(class_id, root_elem)
-    response.from_xml(root_elem)
+    response.from_xml(root_elem, handle)
     return response

--- a/ucsmsdk/utils/comparesyncmo.py
+++ b/ucsmsdk/utils/comparesyncmo.py
@@ -95,7 +95,7 @@ class _MoDiff(object):
         return None
 
 
-def _update_mo_dn_along_with_naming_properties(mo, ref_dn):
+def _update_mo_dn_and_naming_props(mo, ref_dn):
     """
     Internal method to modify the naming properties of mo using dn.
     """
@@ -134,7 +134,7 @@ def _translate_managed_object(mo, xlate_org, xlate_map):
                 ref_dn = re.sub("^%s/" % (match_obj.group(0)),
                                 "%s/" % xlate_org,
                                 mo.dn)
-            _update_mo_dn_along_with_naming_properties(mo, ref_dn)
+            _update_mo_dn_and_naming_props(mo, ref_dn)
 
     if xlate_map is not None:
         diff_dn = mo.dn
@@ -151,7 +151,7 @@ def _translate_managed_object(mo, xlate_org, xlate_map):
                                 "%s/" % xlate_map[diff_dn],
                                 mo.dn)
                 break
-        _update_mo_dn_along_with_naming_properties(mo, ref_dn)
+        _update_mo_dn_and_naming_props(mo, ref_dn)
 
     return mo
 
@@ -249,7 +249,7 @@ def _compare_known_mo(from_mo, to_mo, diff, include_operational=False,
                 diff.append(prop)
 
 
-def _compare_unknown_mo(from_mo, to_mo, diff, version_filter):
+def _compare_unknown_mo(from_mo, to_mo, diff, version_filter=True):
     """
     Internal function to compare if any or both of the  ref and diff obj is
     unknown mo.

--- a/ucsmsdk/utils/comparesyncmo.py
+++ b/ucsmsdk/utils/comparesyncmo.py
@@ -1,0 +1,489 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the api used to provide compare and sync functionality
+within ucsm or across ucsm.
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import re
+import logging
+
+from .. import ucsgenutils
+from .. import ucscoreutils
+from ..ucscoremeta import MoPropertyMeta, MoMeta
+from ..ucsexception import UcsWarning, UcsValidationException
+from ..ucsmo import GenericMo
+
+log = logging.getLogger('ucs')
+
+skip_mos = ["LsVersionBeh", "LsmaintAck", "LsIssues", "VnicIpV4PooledAddr",
+            "VnicDynamicCon", "LsVConAssign", "ComputePooledSlot",
+            "ComputePooledRackUnit", "VnicIPv4PooledIscsiAddr",
+            "IppoolPooled", "IqnpoolPooled", "MacpoolPooled",
+            "UuidpoolPooled", "VnicConnDef", "VnicFcGroupDef",
+            "LsServerExtension"]
+
+
+class _CompareStatus(object):
+    """
+    Internal class used as enum.
+    """
+
+    TYPES_DIFFERENT = 0
+    PROPS_DIFFERENT = 1
+    EQUAL = 2
+
+
+class _PropDiff(object):
+    """
+    Internal class for property delta
+    """
+    def __init__(self, prop, old_value, new_value):
+        self.prop = prop
+        self.old_value = old_value
+        self.new_value = new_value
+
+
+class _MoDiff(object):
+    """
+    This class represents difference object.
+    """
+
+    REMOVE = "<="
+    ADD_MODIFY = "=>"
+    EQUAL = "=="
+
+    def __init__(self, input_object, side_indicator, diff_property=None,
+                 ref_values=None, diff_values=None):
+        self.input_object = input_object
+        self.dn = input_object.dn
+        self.side_indicator = side_indicator
+        self.diff_property = diff_property
+
+        if ref_values:
+            self.ref_prop_values = ref_values
+        else:
+            self.ref_prop_values = {}
+
+        if diff_values:
+            self.diff_prop_values = diff_values
+        else:
+            self.diff_prop_values = {}
+
+    def get_prop_diff(self, prop):
+        if prop in self.ref_prop_values and prop in self.diff_prop_values:
+            prop_name = ""
+            for key in self.ref_prop_values:
+                if prop.lower() == key.lower():
+                    prop_name = key
+                    break
+            return _PropDiff(prop_name, self.ref_prop_values[prop],
+                             self.diff_prop_values[prop])
+        return None
+
+
+def _compare(from_mo, to_mo, diff, include_operational=False):
+    """
+    Internal method to support compare reference and difference object.
+    """
+
+    if from_mo.get_class_id() != to_mo.get_class_id():
+        return _CompareStatus.TYPES_DIFFERENT
+
+    # compare for unknown class_id
+    if isinstance(from_mo, GenericMo) or isinstance(to_mo, GenericMo):
+        for prop in from_mo.properties:
+            if prop in to_mo.properties:
+                if from_mo.properties[prop] != to_mo.properties[prop]:
+                    diff.append(prop)
+
+    # compare for known class_id
+    else:
+        for prop in sorted(from_mo.prop_meta):
+            mo_property_meta = from_mo.prop_meta[prop]
+            if mo_property_meta is not None:
+                if not include_operational and (
+                        mo_property_meta.access == MoPropertyMeta.INTERNAL or
+                        mo_property_meta.access == MoPropertyMeta.READ_ONLY):
+                    continue
+                if prop in to_mo.__dict__ \
+                        and getattr(from_mo, prop) != getattr(to_mo, prop):
+                    diff.append(prop)
+
+        # comparing xtra property
+        from_xtra_props = from_mo._ManagedObject__xtra_props
+        to_xtra_props = to_mo._ManagedObject__xtra_props
+        if from_xtra_props:
+            for prop in from_xtra_props:
+                if prop in to_xtra_props and from_xtra_props[prop].value != \
+                        to_xtra_props[prop].value:
+                    # diff.append(prop)
+                    UcsWarning("Ignoring xtra property '%s' of '%s'" % (
+                        prop, from_mo.dn))
+
+    if len(diff) > 0:
+        return _CompareStatus.PROPS_DIFFERENT
+
+    return _CompareStatus.EQUAL
+
+
+def _update_mo_dn_along_with_naming_properties(mo, ref_dn):
+    """
+    Internal method to modify the naming properties of mo using dn.
+    """
+
+    # modify diffmo dn with refmo dn
+    mo.__dict__['dn'] = ref_dn
+
+    # modify diffmo rn with refmo rn
+    ref_rn = re.sub(r'^.*/', '', ref_dn)
+    mo.__dict__['rn'] = ref_rn
+
+    # modify diff mo naming properties using ref_rn
+    naming_prop_dict = ucscoreutils.get_naming_props(rn_str=ref_rn,
+                                                     rn_pattern=mo.mo_meta.rn)
+    for prop in naming_prop_dict:
+        mo.__dict__[prop] = naming_prop_dict[prop]
+
+
+def _translate_managed_object(mo, xlate_org, xlate_map):
+    """
+    Internal method used to translate a managed object which helps in comparing
+    two mo with different dn.
+    """
+
+    ref_dn = None
+    if xlate_org is not None:
+        match_obj = re.match(
+            r'^(org-[\-\.:_a-zA-Z0-9]{1,16}/)*org-[\-\.:_a-zA-Z0-9]{1,16}',
+            mo.dn)
+        if match_obj:
+            if mo.get_class_id() == "OrgOrg":
+                ref_dn = re.sub("%s" % (match_obj.group(0)),
+                                "%s" % xlate_org,
+                                mo.dn)
+            else:
+                ref_dn = re.sub("^%s/" % (match_obj.group(0)),
+                                "%s/" % xlate_org,
+                                mo.dn)
+            _update_mo_dn_along_with_naming_properties(mo, ref_dn)
+
+    if xlate_map is not None:
+        diff_dn = mo.dn
+        if diff_dn in xlate_map:
+            ref_dn = xlate_map[diff_dn]
+        else:
+            diff_dn = re.sub(r'[/]*[^/]+$', '', diff_dn)
+            while diff_dn is not None or diff_dn == "":
+                if diff_dn not in xlate_map:
+                    diff_dn = re.sub(r'[/]*[^/]+$', '', diff_dn)
+                    continue
+
+                ref_dn = re.sub("^%s/" % diff_dn,
+                                "%s/" % xlate_map[diff_dn],
+                                mo.dn)
+                break
+        _update_mo_dn_along_with_naming_properties(mo, ref_dn)
+
+    return mo
+
+
+def write_mo_diff(diff_obj):
+    """
+    Writes the difference managedObject(output of CompareManagedObject)
+    on the terminal.
+    """
+
+    tab_size = 8
+    if isinstance(diff_obj, list) and len(diff_obj) > 0:
+        if isinstance(diff_obj[0], _MoDiff):
+            print("dn".ljust(tab_size*10), "input_object".ljust(tab_size*4),
+                  "side_indicator".ljust(tab_size*3), "diff_property")
+            print("--".ljust(tab_size*10), "-----------".ljust(tab_size*4),
+                  "-------------".ljust(tab_size*3), "------------")
+        for mo in diff_obj:
+            if isinstance(mo, _MoDiff):
+                print(str(mo.dn).ljust(tab_size*10),
+                      str(mo.input_object.get_class_id()).ljust(tab_size*4),
+                      str(mo.side_indicator).ljust(tab_size*3),
+                      str(mo.diff_property))
+
+
+def compare_ucs_mo(ref_handle, ref_obj,
+                   diff_handle, diff_obj,
+                   exclude_different=False,
+                   include_equal=False,
+                   no_version_filter=False,
+                   include_operational=False,
+                   xlate_org=None, xlate_map=None):
+    """
+    Compares the state of two managed objects with same dn.
+
+    Args:
+        ref_handle (UcsHandle): connect handle of reference ucsm
+        ref_obj (list): list of Managed Objects of reference ucsm
+        diff_handle (UcsHandle): connect handle of difference ucsm
+        diff_obj (list): list of Managed Objects of difference ucsm
+        exclude_different (bool): by default False. If set to True, will
+                                  compare mos only which exist on both
+                                  reference and difference ucsm respectively
+        include_equal (bool): by default False. If set to True, will also
+                              display properties which are equal
+        no_version_filter (bool): by default False: If set to True, ignore
+                                  properties which is introduced in later ucsm
+                                  version than reference ucsm
+        include_operational (bool): by default False: If set to True, compares
+                                    all the properties of mo.
+        xlate_org (str): org-dn, should be used compare objects of same type
+                         under different org. org-dn of reference mo.
+        xlate_map (dict) : {"difference_dn": "reference_dn"}
+                           Should be used to compare objects of same type with
+                           different dn.
+    Returns:
+        List of MoDiff objects:
+        MoDiff Object : dn - dn of Managed Object
+                        input_object - Managed Object
+                        side_indicator -
+                            "=>" Add the diff obj to ref ucsm
+                              or
+                              Modify the ref object by diff object on ref ucsm
+
+                            "<=" Removes the ref obj from ref ucsm
+
+                            "==" object is equal on both ref and diff ucsm
+                        diff_property  - property list with different value
+
+    Example:
+        #1
+        ref_mos = [ref_handle.query_dn(dn="org-root/ls-sp")]
+        diff_mos = [diff_handle.query_dn(dn="org-root/ls-sp")]
+        compare_ucs_mo(ref_handle, ref_mos,
+                                   diff_handle, diff_mos)
+
+        #2
+        ref_mos = [ref_handle.query_dn(dn="org-root/org-ref/ls-sp")]
+        diff_mos = [diff_handle.query_dn(dn="org-root/org-diff/ls-sp")]
+        compare_ucs_mo(ref_handle, ref_mos,
+                                   diff_handle, diff_mos,
+                                   xlate_org = "org-root/org-ref")
+
+        #3
+        ref_mos = [ref_handle.query_dn(dn="org-root/ls-ref")]
+        diff_mos = [diff_handle.query_dn(dn="org-root/ls-diff")]
+        compare_ucs_mo(ref_handle, ref_mos, diff_handle, diff_mos,
+                        xlate_map = {"org-root/ls-diff": "org-root/ls-ref"})
+    """
+
+    reference_dict = {}
+    difference_dict = {}
+
+    if ref_obj is not None and \
+            isinstance(ref_obj, list) and len(ref_obj) > 0:
+        for mo in ref_obj:
+            if mo is None:
+                continue
+            if isinstance(mo, GenericMo):
+                if ucsgenutils.word_u(mo.get_class_id()) in skip_mos:
+                    continue
+            elif mo.get_class_id() in skip_mos or \
+                    mo.mo_meta.inp_out == MoMeta.ACCESS_TYPE_OUTPUTONLY or \
+                    (mo.mo_meta.inp_out == MoMeta.ACCESS_TYPE_IO
+                     and len(mo.mo_meta.access) == 1
+                     and mo.mo_meta.access[0] == "read-only"):
+                continue
+            reference_dict[mo.dn] = mo
+    # log.debug("reference_dict: %s" % reference_dict)
+
+    if diff_obj is not None and \
+            isinstance(diff_obj, list) and len(diff_obj) > 0:
+        for mo in diff_obj:
+            if mo is None:
+                continue
+            if isinstance(mo, GenericMo):
+                if ucsgenutils.word_u(mo.get_class_id()) in skip_mos:
+                    continue
+            elif mo.get_class_id() in skip_mos or \
+                    mo.mo_meta.inp_out == MoMeta.ACCESS_TYPE_OUTPUTONLY or \
+                    (mo.mo_meta.inp_out == MoMeta.ACCESS_TYPE_IO
+                     and len(mo.mo_meta.access) == 1
+                     and mo.mo_meta.access[0] == "read-only"):
+                continue
+            translated_mo = _translate_managed_object(mo, xlate_org, xlate_map)
+            difference_dict[translated_mo.dn] = translated_mo
+    # log.debug("difference_dict: %s" % difference_dict)
+
+    # union of reference and difference
+    dn_list = list(set.union(set(reference_dict), set(difference_dict)))
+    dn_list = sorted(dn_list)
+    diff_output = []
+
+    for dn in dn_list:
+        if dn not in difference_dict:
+            ref_mo = reference_dict[dn].clone()
+            if not exclude_different:
+                mo_diff = _MoDiff(ref_mo, _MoDiff.REMOVE)
+                diff_output.append(mo_diff)
+        elif dn not in reference_dict:
+            diff_mo = difference_dict[dn].clone()
+            if not exclude_different:
+                mo_diff = _MoDiff(diff_mo, _MoDiff.ADD_MODIFY)
+                diff_output.append(mo_diff)
+        else:
+            ref_mo = reference_dict[dn].clone()
+            diff_mo = difference_dict[dn].clone()
+            diff_props = []
+
+            if not no_version_filter:
+                if not isinstance(ref_mo, GenericMo) and \
+                        ref_handle.version is not None:
+                    for prop in ref_mo.prop_meta:
+                        prop_meta = ref_mo.prop_meta[prop]
+                        if ref_handle.version < prop_meta.version or \
+                                prop_meta.access == MoPropertyMeta.INTERNAL:
+                            del ref_mo.__dict__[prop]  # check this
+
+                if not isinstance(diff_mo, GenericMo) and \
+                        diff_handle.version is not None:
+                    for prop in diff_mo.prop_meta:
+                        prop_meta = diff_mo.prop_meta[prop]
+                        if diff_handle.version < prop_meta.version or \
+                                prop_meta.access == MoPropertyMeta.INTERNAL:
+                            del diff_mo.__dict__[prop]  # check this
+
+            # compare both mo for property and type
+            diff_status = _compare(ref_mo, diff_mo, diff_props,
+                                   include_operational)
+
+            if diff_status == _CompareStatus.EQUAL and include_equal:
+                mo_diff = _MoDiff(ref_mo, _MoDiff.EQUAL)
+                diff_output.append(mo_diff)
+            elif diff_status == _CompareStatus.TYPES_DIFFERENT and \
+                    not exclude_different:
+                mo_diff = _MoDiff(ref_mo, _MoDiff.REMOVE)
+                diff_output.append(mo_diff)
+                mo_diff = _MoDiff(diff_mo, _MoDiff.ADD_MODIFY)
+                diff_output.append(mo_diff)
+            elif diff_status == _CompareStatus.PROPS_DIFFERENT and \
+                    not exclude_different:
+                ref_values = {}
+                diff_values = {}
+                for prop in diff_props:
+                    ref_values[prop] = getattr(ref_mo, prop)
+                    diff_values[prop] = getattr(diff_mo, prop)
+                mo_diff = _MoDiff(diff_mo, _MoDiff.ADD_MODIFY,
+                                  diff_props, ref_values, diff_values)
+                diff_output.append(mo_diff)
+
+    return diff_output
+
+
+def sync_ucs_mo(ref_handle, difference,
+                delete_not_present=False,
+                no_version_filter=False):
+    """
+    syncs the difference object on reference ucsm.
+    In other words, make the state of reference ucsm for the respective
+    ref object same as difference object on reference ucsm.
+
+    Args:
+        ref_handle (UcsHandle): connect handle of reference ucsm
+        difference (list of MoDiff objects): output of compare-ucs-mo api
+        delete_not_present (bool): by dafault False. If set to true, will
+                                   delete ref mo which does not exist on
+                                   difference ucsm
+        no_version_filter (bool): by default False: If set to True, ignore
+                                  properties which is introduced in later ucsm
+                                  version than reference ucsm
+
+    Returns:
+        None
+
+    Example:
+        #1
+        ref_mos = [ref_handle.query_dn(dn="org-root/ls-sp")]
+        diff_mos = [diff_handle.query_dn(dn="org-root/ls-sp")]
+        difference = compare_ucs_mo(ref_handle, ref_mos,diff_handle, diff_mos)
+        sync_ucs_mo(ref_handle, difference=difference, delete_not_present=True)
+    """
+
+    if difference is None or \
+            (isinstance(difference, list) and len(difference) == 0):
+        raise UcsValidationException(
+            "difference object parameter is not provided.")
+
+    to_commit = False
+
+    for mo_diff in difference:
+        mo = mo_diff.input_object
+        class_id = mo.get_class_id()
+
+        if isinstance(mo, GenericMo):
+            UcsWarning("Ignoring '%s'.Unknown ClasId '%s'" % (mo.dn, class_id))
+            continue
+
+        # Remove
+        if mo_diff.side_indicator == _MoDiff.REMOVE and delete_not_present:
+            log.debug("removing mo '%s'." % mo.dn)
+            ref_handle.remove_mo(mo)
+            to_commit = True
+
+        if not no_version_filter:
+            mo_meta = mo.mo_meta
+            if ref_handle.version < mo_meta.version:
+                UcsWarning("Ignoring unsupported class_id '%s' for dn '%s'" %
+                           (class_id, mo.dn))
+                continue
+
+        # Add or Modify
+        if mo_diff.side_indicator == _MoDiff.ADD_MODIFY:
+            add_exists = False
+            if isinstance(mo, GenericMo):
+                mo_meta = None
+            else:
+                mo_meta = mo.mo_meta
+
+            if mo_meta is not None and 'Add' in mo_meta.verbs:
+                add_exists = True
+
+            # Add
+            if add_exists and (mo_diff.diff_property is None
+                               or len(mo_diff.diff_property) == 0):
+                log.debug("adding mo '%s'" % mo.dn)
+                mo.mark_dirty()
+                ref_handle.add_mo(mo)
+                to_commit = True
+
+            # Modify the Managed Object
+            else:
+                if mo_diff.diff_property is None \
+                        or len(mo_diff.diff_property) == 0:
+                    continue
+                set_flag = False
+                for prop in mo_diff.diff_property:
+                    if mo.prop_meta[prop].access == MoPropertyMeta.READ_WRITE:
+                        setattr(mo, prop, getattr(mo, prop))
+                        set_flag = True
+                if not set_flag:
+                    log.debug("No Configurable Properties Changed for mo '%s'"
+                              % mo.dn)
+                else:
+                    log.debug("set mo '%s'" % mo.dn)
+                    ref_handle.set_mo(mo)
+                    to_commit = True
+
+    if to_commit:
+        ref_handle.commit()

--- a/ucsmsdk/utils/comparesyncmo.py
+++ b/ucsmsdk/utils/comparesyncmo.py
@@ -120,6 +120,10 @@ def _translate_managed_object(mo, xlate_org, xlate_map):
     two mo with different dn.
     """
 
+    if not xlate_org and not xlate_map:
+        return mo
+
+    mo = mo.clone()
     ref_dn = None
     if xlate_org is not None:
         match_obj = re.match(


### PR DESCRIPTION
Added API "compare_ucs_mo" and "sync_ucs_mo" to compare and sync managed objects with same dn across different Ucs domains. Aim is to make ref objects same as diff objects.
Below is the code snippet to compare org across ucs domain and its output.
```
ref_mos = ref_handle.query_dn(dn="org-root/org-test", hierarchy=True)
diff_mos = diff_handle.query_dn(dn="org-root/org-test", hierarchy=True)
compare_ucs_mo(ref_handle, ref_mos, diff_handle, diff_mos)

==============================
dn                                     					input_object   side_indicator     diff_property
--                                     					-----------    -------------      ------------
org-root/org-test                      					OrgOrg         =>                 ['descr']
org-root/org-test/ls-add_sp_exist_only_in_diff	        LsServer       =>                 None
org-root/org-test/ls-remove_sp_exist_only_in_ref       	LsServer       <=                 None
org-root/org-test/ls-modify_same_sp_with_diff_props    	LsServer       =>                 ['usr_lbl']
```