### PR TITLE
Helper APIs to navigate Mo, class Ids, Mo Properties

### DIFF
--- a/tests/coreutils/__init__.py
+++ b/tests/coreutils/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/coreutils/test_get_meta_info.py
+++ b/tests/coreutils/test_get_meta_info.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nose.tools import *
+from ucsmsdk.ucscoreutils import get_meta_info
+
+
+def test_known_class():
+    meta = get_meta_info(class_id="OrGoRg")
+    xml_attribute = meta.xml_attribute
+    assert_equal(xml_attribute, "orgOrg")
+
+
+@raises(ValueError)
+def test_unknown_class():
+    get_meta_info(class_id="unknown")
+
+
+def test_known_class_props():
+    meta = get_meta_info(class_id="OrGoRg")
+    properties = len(meta.props)
+    assert_not_equal(properties, 0)
+
+
+def test_known_class_props_meta():
+    meta = get_meta_info(class_id="OrGoRg")
+    xml_attribute = meta.props['name'].xml_attribute
+    assert_equal(xml_attribute, 'name')
+
+
+def test_include_prop_false():
+    meta = get_meta_info(class_id="OrGoRg", include_prop=False)
+    properties = len(meta.props)
+    assert_equal(properties, 0)

--- a/tests/coreutils/test_get_meta_info.py
+++ b/tests/coreutils/test_get_meta_info.py
@@ -21,9 +21,9 @@ def test_known_class():
     assert_equal(xml_attribute, "orgOrg")
 
 
-@raises(ValueError)
 def test_unknown_class():
-    get_meta_info(class_id="unknown")
+    meta = get_meta_info(class_id="unknown")
+    assert_equal(meta, None)
 
 
 def test_known_class_props():

--- a/ucsmsdk/ucscoremeta.py
+++ b/ucsmsdk/ucscoremeta.py
@@ -41,6 +41,8 @@ class UcsVersion(object):
         if version is None:
             return None
 
+        self.__version = version
+
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
@@ -95,6 +97,11 @@ class UcsVersion(object):
         """Getter Method of UcsVersion Class"""
         return self.__patch
 
+    @property
+    def version(self):
+        """Getter Method of UcsVersion Class"""
+        return self.__version
+
     def compare_to(self, version):
         """Method to compare UcsVersion."""
         if version is None or not isinstance(version, UcsVersion):
@@ -119,6 +126,9 @@ class UcsVersion(object):
 
     def __le__(self, version):
         return self.compare_to(version) <= 0
+
+    def __str__(self):
+        return self.__version
 
 
 class MoPropertyRestriction(object):
@@ -309,6 +319,42 @@ class MoPropertyMeta(object):
             log.debug(error_msg)
             return False
         return True
+
+    def __str__(self):
+        """
+        Method to return string representation.
+        """
+
+        access_dict = {0: "NAMING",
+                       1: "CREATE_ONLY",
+                       2: "READ_ONLY",
+                       3: "READ_WRITE",
+                       4: "INTERNAL"}
+
+        ts = 8
+        out_str = "\n"
+        out_str += "Property".ljust(ts * 4) + str(self.name) + "\n"
+        out_str += ("-" * len("Property")).ljust(ts * 4) + "-" * len(
+            self.name) + "\n"
+        out_str += str("xml_attribute").ljust(ts * 4) + ':' + str(
+            self.xml_attribute) + "\n"
+        out_str += str("field_type").ljust(ts * 4) + ':' + str(
+            self.field_type) + "\n"
+        out_str += str("min_version").ljust(ts * 4) + ':' + str(
+            self.version) + "\n"
+        out_str += str("access").ljust(ts * 4) + ':' + str(
+            access_dict[self.access]) + "\n"
+        out_str += str("min_length").ljust(ts * 4) + ':' + str(
+            self.restriction.min_length) + "\n"
+        out_str += str("max_length").ljust(ts * 4) + ':' + str(
+            self.restriction.max_length) + "\n"
+        out_str += str("pattern").ljust(ts * 4) + ':' + str(
+            self.restriction.pattern) + "\n"
+        out_str += str("value_set").ljust(ts * 4) + ':' + str(
+            self.restriction.value_set) + "\n"
+        out_str += str("range_val").ljust(ts * 4) + ':' + str(
+            self.restriction.range_val)
+        return out_str
 
 
 class MoMeta(object):

--- a/ucsmsdk/ucscoreutils.py
+++ b/ucsmsdk/ucscoreutils.py
@@ -592,11 +592,13 @@ def search_class_id(class_id):
     class_ids = sorted([cid for cid in ucsmeta.MO_CLASS_ID
                         if re.search(l_class_id, cid, re.IGNORECASE)])
     if class_ids:
-        log.info("<%s> is not present.\n"
-                 "Related available class_ids are:\n%s" %
-                 (class_id, "\n".join(class_ids)))
+        log.info('"%s" did not match any available Class Ids.\n'
+                 'Related Class Ids are:\n%s\n%s' %
+                 (class_id,
+                  "-"*len("Related Class Ids are:"),
+                  "\n".join(class_ids)))
     else:
-        log.info("<%s> is not present." % class_id)
+        log.info('"%s" did not match any available Class Ids.' % class_id)
 
 
 def get_meta_info(class_id, include_prop=True,
@@ -611,6 +613,8 @@ def get_meta_info(class_id, include_prop=True,
         break_level (int): display the hierarchy till respective level.
 
     Returns:
+        None: If class_id is not present in meta.
+        Or
         ClassIdMeta Object: class_id
                             xml_attribute
                             rn
@@ -635,8 +639,7 @@ def get_meta_info(class_id, include_prop=True,
 
     meta_class_id = search_class_id(class_id)
     if not meta_class_id:
-        raise ValueError("<%s> is not present. Provide Correct Class Id." %
-                         class_id)
+        return
 
     if show_tree:
         _show_tree(class_id=meta_class_id, break_level=break_level)


### PR DESCRIPTION
Added API:
`search_class_id`  To find a given class_id exist in meta.(case insensitive)
`get_meta_info`  This gives the meta info for the respective class_id and its associated properties and prints the mo hierarchy tree.
```
from ucsmsdk.ucscoreutils import get_meta_info
meta = get_meta_info(class_id="MeMOryaRRay")

[ComputeBoard]
  |-MemoryArray
     |-FaultInst
     |-MemoryArrayEnvStats
     |  |-MemoryArrayEnvStatsHist
     |-MemoryUnit
        |-FaultInst
        |-MemoryErrorStats
        |-MemoryUnitEnvStats
           |-MemoryUnitEnvStatsHist

ClassId                         MemoryArray
-------                         -----------
xml_attribute                   :memoryArray
rn                              :memarray-[id]
min_version                     :1.0(1e)
access                          :InputOutput
access_privilege                :['read-only']
parents                         :['computeBoard']
children                        :['faultInst', 'memoryArrayEnvStats', 'memoryUnit']

Property                        child_action
--------                        ------------
xml_attribute                   :childAction
field_type                      :string
min_version                     :1.0(1e)
access                          :INTERNAL
min_length                      :None
max_length                      :None
pattern                         :((deleteAll|ignore|deleteNonPresent),){0,2}(deleteAll|ignore|deleteNonPresent){0,1}
value_set                       :[]
range_val                       :[]

Property                        cpu_id
--------                        ------
xml_attribute                   :cpuId
field_type                      :uint
min_version                     :1.0(1e)
access                          :READ_ONLY
min_length                      :None
max_length                      :None
pattern                         :None
value_set                       :[]
range_val                       :[]

Property                        curr_capacity
--------                        -------------
xml_attribute                   :currCapacity
field_type                      :string
min_version                     :1.0(1e)
access                          :READ_ONLY
min_length                      :None
max_length                      :None
pattern                         :None
value_set                       :['unspecified']
range_val                       :['0-4294967295']

:
:
:
:

Property                        voltage
--------                        -------
xml_attribute                   :voltage
field_type                      :string
min_version                     :1.0(1e)
access                          :READ_ONLY
min_length                      :None
max_length                      :None
pattern                         :None
value_set                       :['lower-critical', 'lower-non-critical', 'lower-non-recoverable', 'not-supported', 'ok', 'unknown', 'upper-critical', 'upper-non-critical', 'upper-non-recoverable']
range_val                       :[]
```

`include_prop=False`  will not display the properties.
```
meta = get_meta_info(class_id="MemoryArray", include_prop=False)
```

`show_tree=False` will not display the tree.
```
meta = get_meta_info(class_id="MemoryArray", show_tree=False)
```

```
meta = get_meta_info(class_id="MemoryArray", include_prop=False, show_tree=False)
print("\n-----------------------------------------------------")
print(meta.xml_attribute)
print(meta.parents)
print(meta.children)

ClassId                         MemoryArray
-------                         -----------
xml_attribute                   :memoryArray
rn                              :memarray-[id]
min_version                     :1.0(1e)
access                          :InputOutput
access_privilege                :['read-only']
parents                         :['computeBoard']
children                        :['faultInst', 'memoryArrayEnvStats', 'memoryUnit']

-----------------------------------------------------
memoryArray
['computeBoard']
['faultInst', 'memoryArrayEnvStats', 'memoryUnit']
```

Class Id not present but related class Id present in meta.
```
meta = get_meta_info(class_id="MeM")

2016-03-21 11:32:30,899 - ucs - INFO - "MeM" did not match any available Class Ids.
Related Class Ids are:
----------------------
BiosVfMaximumMemoryBelow4GB
BiosVfMemoryMappedIOAbove4GB
BiosVfSelectMemoryRASConfiguration
ComputeMemoryConfigPolicy
ComputeMemoryConfiguration
ComputeMemoryUnitConstraintDef
EquipmentMemoryUnitCapProvider
EquipmentMemoryUnitDiscoveryModifierDef
FabricVsanMembership
InitiatorMemberEp
LsZoneInitiatorMember
LsZoneTargetMember
MemoryArray
MemoryArrayEnvStats
MemoryArrayEnvStatsHist
MemoryBufferUnit
MemoryBufferUnitEnvStats
MemoryBufferUnitEnvStatsHist
MemoryErrorStats
MemoryQual
MemoryRuntime
MemoryRuntimeHist
MemoryUnit
MemoryUnitEnvStats
MemoryUnitEnvStatsHist
PowerChassisMember
PowerRackUnitMember
StorageVDMemberEp
SwZoneInitiatorMember
SwZoneTargetMember
```

Class Id and no matching Class Id present in meta.
```
meta = get_meta_info(class_id="MeX")

2016-03-21 11:33:39,485 - ucs - INFO - "MeX" did not match any available Class Ids.
```