### PR TITLE
Import error fix for python3 support

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,124 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nose.tools import *
+
+
+def test_import_ucsmsdk():
+    import ucsmsdk
+
+
+def test_import_ucsbasetype():
+    from ucsmsdk import ucsbasetype
+
+
+def test_import_ucsconstants():
+    from ucsmsdk import ucsconstants
+
+
+def test_import_ucscore():
+    from ucsmsdk import ucscore
+
+
+def test_import_ucscoremeta():
+    from ucsmsdk import ucscoremeta
+
+
+def test_import_ucscoreutils():
+    from ucsmsdk import ucscoreutils
+
+
+def test_import_ucsdriver():
+    from ucsmsdk import ucsdriver
+
+
+def test_import_ucseventhandler():
+    from ucsmsdk import ucseventhandler
+
+
+def test_import_ucsexception():
+    from ucsmsdk import ucsexception
+
+
+def test_import_ucsfilter():
+    from ucsmsdk import ucsfilter
+
+
+def test_import_ucsfiltertype():
+    from ucsmsdk import ucsfiltertype
+
+
+def test_import_ucsgenutils():
+    from ucsmsdk import ucsgenutils
+
+
+def test_import_ucshandle():
+    from ucsmsdk import ucshandle
+
+
+def test_import_ucsmeta():
+    from ucsmsdk import ucsmeta
+
+
+def test_import_ucsmethod():
+    from ucsmsdk import ucsmethod
+
+
+def test_import_ucsmethodfactory():
+    from ucsmsdk import ucsmethodfactory
+
+
+def test_import_ucsmo():
+    from ucsmsdk import ucsmo
+
+
+def test_import_ucssession():
+    from ucsmsdk import ucssession
+
+
+def test_import_ucsxmlcodec():
+    from ucsmsdk import ucsxmlcodec
+
+
+def test_import_utils():
+    import ucsmsdk.utils
+
+
+def test_import_ccoimage():
+    from ucsmsdk.utils import ccoimage
+
+
+def test_import_comparesyncmo():
+    from ucsmsdk.utils import comparesyncmo
+
+
+def test_import_converttopython():
+    from ucsmsdk.utils import converttopython
+
+
+def test_import_ucsbackup():
+    from ucsmsdk.utils import ucsbackup
+
+
+def test_import_ucsguilaunch():
+    from ucsmsdk.utils import ucsguilaunch
+
+
+def test_import_ucskvmlaunch():
+    from ucsmsdk.utils import ucskvmlaunch
+
+
+def test_import_ucstechsupport():
+    from ucsmsdk.utils import ucstechsupport
+
+

--- a/ucsmsdk/ucsfilter.py
+++ b/ucsmsdk/ucsfilter.py
@@ -195,7 +195,7 @@ def handle_filter_max_component_limit(handle, l_filter):
         parent_filter = AndFilter()
         child_filter = AndFilter()
         parent_filter.child_add(child_filter)
-        for childf in l_filter.GetChild():
+        for childf in l_filter.child:
             if isinstance(childf, AbstractFilter):
                 if child_filter.child_count() == max_components:
                     child_filter = AndFilter()
@@ -206,7 +206,7 @@ def handle_filter_max_component_limit(handle, l_filter):
         parent_filter = OrFilter()
         child_filter = OrFilter()
         parent_filter.child_add(child_filter)
-        for childf in l_filter.GetChild():
+        for childf in l_filter.child:
             if isinstance(childf, AbstractFilter):
                 if child_filter.child_count() == max_components:
                     child_filter = OrFilter()

--- a/ucsmsdk/utils/ucsbackup.py
+++ b/ucsmsdk/utils/ucsbackup.py
@@ -127,7 +127,7 @@ def backup_ucs(handle, backup_type, file_dir, file_name, timeout_in_sec=600,
         handle.file_download(url_suffix=file_source,
                              file_dir=file_dir,
                              file_name=file_name)
-    except Exception, err:
+    except Exception as err:
         UcsWarning("Download Error.....")
         UcsWarning(str(err))
 

--- a/ucsmsdk/utils/ucstechsupport.py
+++ b/ucsmsdk/utils/ucstechsupport.py
@@ -257,7 +257,7 @@ def get_ucs_tech_support(handle,
             handle.file_download(url_suffix=url_suffix,
                                  file_dir=file_dir,
                                  file_name=file_name)
-        except Exception, err:
+        except Exception as err:
             UcsWarning(str(err))
 
     # remove tech support file from ucs


### PR DESCRIPTION
Fix in `ucsbackup and ucstechsupport`.
Replaced unknown reference GetChild() method with child attribute in ucsfilter.
Added testcase `test_import` to catch import specific issue in future.