### PR TITLE
pep8 fixes

### DIFF
--- a/ucsmsdk/ucscore.py
+++ b/ucsmsdk/ucscore.py
@@ -146,8 +146,8 @@ class AbstractFilter(UcsBase):
     def to_xml(self, xml_doc=None, option=None, elem_name=None):
         """This method writes the xml representation of the Method object."""
         xml_obj = self.elem_create(class_tag=self._tag_name,
-                                       xml_doc=xml_doc,
-                                       override_tag=elem_name)
+                                   xml_doc=xml_doc,
+                                   override_tag=elem_name)
         for key in self.__dict__:
             if key.startswith("_"):
                 continue
@@ -170,8 +170,8 @@ class BaseObject(UcsBase):
     def to_xml(self, xml_doc=None, option=None, elem_name=None):
         """This method writes the xml representation of the Method object."""
         xml_obj = self.elem_create(class_tag=self._tag_name,
-                                       xml_doc=xml_doc,
-                                       override_tag=elem_name)
+                                   xml_doc=xml_doc,
+                                   override_tag=elem_name)
         for key in self.__dict__:
             if key.startswith("_"):
                 continue
@@ -188,8 +188,8 @@ class BaseObject(UcsBase):
         self._handle = handle
         if elem.attrib:
             for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
-                self.attr_set(ucsgenutils.convert_to_python_var_name(attr_name)
-                            , str(attr_value))
+                self.attr_set(ucsgenutils.convert_to_python_var_name(
+                    attr_name), str(attr_value))
 
         child_elems = elem.getchildren()
         if child_elems:

--- a/ucsmsdk/ucscoreutils.py
+++ b/ucsmsdk/ucscoreutils.py
@@ -68,7 +68,8 @@ def get_ucs_obj(class_id, elem, mo_obj=None):
         if 'topRoot' in mo_class.mo_meta.parents:
             mo_obj = mo_class(from_xml_response=True, **mo_class_param_dict)
         else:
-            mo_obj = mo_class(parent_mo_or_dn=p_dn, from_xml_response=True, **mo_class_param_dict)
+            mo_obj = mo_class(parent_mo_or_dn=p_dn,
+                              from_xml_response=True, **mo_class_param_dict)
         return mo_obj
     elif class_id in OTHER_TYPE_CLASS_ID:
         module_ = load_module(class_id)
@@ -85,7 +86,8 @@ def get_ucs_obj(class_id, elem, mo_obj=None):
     elif mo_obj:
         p_dn = mo_obj.dn
 
-    mo_obj = ucsmo.GenericMo(class_id=elem.tag, parent_mo_or_dn=p_dn, **elem.attrib)
+    mo_obj = ucsmo.GenericMo(
+        class_id=elem.tag, parent_mo_or_dn=p_dn, **elem.attrib)
     return mo_obj
 
 
@@ -379,7 +381,6 @@ def write_mo_tree(mo, level=0, break_level=None, show_level=[],
     return tree_dict
 
 
-
 def extract_mo_tree_from_config_method_response(method_response,
                                                 break_level=None,
                                                 show_level=[],
@@ -508,7 +509,7 @@ class ClassIdMeta(object):
         out_str = "\n"
         out_str += str("ClassId").ljust(ts * 4) + str(self.class_id) + "\n"
         out_str += ("-" * len("ClassId")).ljust(ts * 4) + "-" * len(
-            self.class_id)+"\n"
+            self.class_id) + "\n"
         out_str += str("xml_attribute").ljust(ts * 4) + ':' + str(
             self.xml_attribute) + "\n"
         out_str += str("rn").ljust(ts * 4) + ':' + str(
@@ -558,7 +559,7 @@ def _show_tree(class_id, break_level=None, level=0, ancestor_str="",
                 _show_tree(child, break_level, level, ancestor_str_, ancestor,
                            total == count)
 
-        ancestor.pop(index-1)
+        ancestor.pop(index - 1)
 
 
 def search_class_id(class_id):
@@ -591,7 +592,7 @@ def search_class_id(class_id):
         log.info('"%s" did not match any available Class Ids.\n'
                  'Related Class Ids are:\n%s\n%s' %
                  (class_id,
-                  "-"*len("Related Class Ids are:"),
+                  "-" * len("Related Class Ids are:"),
                   "\n".join(class_ids)))
     else:
         log.info('"%s" did not match any available Class Ids.' % class_id)

--- a/ucsmsdk/ucsexception.py
+++ b/ucsmsdk/ucsexception.py
@@ -20,6 +20,7 @@ import logging
 
 log = logging.getLogger('ucs')
 
+
 def UcsWarning(warn_str):
     """
     Method to throw warnings.

--- a/ucsmsdk/ucsfilter.py
+++ b/ucsmsdk/ucsfilter.py
@@ -61,7 +61,13 @@ class ParseFilter(object):
         # print prop_, value_, type_, flag_ #logger
 
         if flag_ == "I":
-            value_ = re.sub(r"[a-zA-Z]", lambda x: "[" + x.group().upper() + x.group().lower() + "]", value_)
+            value_ = re.sub(
+                r"[a-zA-Z]",
+                lambda x: "[" +
+                x.group().upper() +
+                x.group().lower() +
+                "]",
+                value_)
 
         if ParseFilter.is_meta_classid:
             class_obj = ucscoreutils.load_class(ParseFilter.class_id)
@@ -116,7 +122,8 @@ class ParseFilter(object):
         return not_filter
 
 
-prop = pp.WordStart(pp.alphas) + pp.Word(pp.alphanums+"_").setResultsName("prop")
+prop = pp.WordStart(pp.alphas) + pp.Word(pp.alphanums +
+                                         "_").setResultsName("prop")
 value = (pp.QuotedString("'") | pp.QuotedString('"') | pp.Word(
     pp.printables, excludeChars=",")).setResultsName("value")
 types_ = pp.oneOf("re eq ne gt ge lt le").setResultsName("types")

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -219,7 +219,7 @@ class UcsHandle(UcsSession):
             dn_set.child_add(dn_obj)
 
         elem = config_resolve_dns(cookie=self.cookie,
-                                         in_dns=dn_set)
+                                  in_dns=dn_set)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -269,7 +269,7 @@ class UcsHandle(UcsSession):
             class_id_set.child_add(class_id_obj)
 
         elem = config_resolve_classes(cookie=self.cookie,
-                                             in_ids=class_id_set)
+                                      in_ids=class_id_set)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -315,8 +315,8 @@ class UcsHandle(UcsSession):
         dn_set.child_add(dn_obj)
 
         elem = config_resolve_dns(cookie=self.cookie,
-                                         in_dns=dn_set,
-                                         in_hierarchical=hierarchy)
+                                  in_dns=dn_set,
+                                  in_hierarchical=hierarchy)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -387,7 +387,7 @@ class UcsHandle(UcsSession):
             raise ValueError("Provide Parameter class_id")
 
         meta_class_id = ucscoreutils.find_class_id_in_mo_meta_ignore_case(
-                                                                class_id)
+            class_id)
         if meta_class_id:
             is_meta_class_id = True
         else:
@@ -401,9 +401,9 @@ class UcsHandle(UcsSession):
             in_filter = None
 
         elem = config_resolve_class(cookie=self.cookie,
-                                              class_id=meta_class_id,
-                                              in_filter=in_filter,
-                                              in_hierarchical=hierarchy)
+                                    class_id=meta_class_id,
+                                    in_filter=in_filter,
+                                    in_hierarchical=hierarchy)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -412,8 +412,8 @@ class UcsHandle(UcsSession):
             return response
 
         out_mo_list = ucscoreutils.extract_molist_from_method_response(
-                                                                    response,
-                                                                    hierarchy)
+            response,
+            hierarchy)
         return out_mo_list
 
     def query_children(self, in_mo=None, in_dn=None, class_id=None,
@@ -488,7 +488,7 @@ class UcsHandle(UcsSession):
 
         if class_id:
             meta_class_id = ucscoreutils.find_class_id_in_mo_meta_ignore_case(
-                                                                class_id)
+                class_id)
             if meta_class_id:
                 is_meta_class_id = True
             else:
@@ -511,8 +511,8 @@ class UcsHandle(UcsSession):
             raise UcsException(response.error_code, response.error_descr)
 
         out_mo_list = ucscoreutils.extract_molist_from_method_response(
-                                                                    response,
-                                                                    hierarchy)
+            response,
+            hierarchy)
 
         return out_mo_list
 
@@ -636,7 +636,7 @@ class UcsHandle(UcsSession):
             config_map.child_add(pair)
 
         elem = config_conf_mos(self.cookie, config_map,
-                                         False)
+                               False)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -653,11 +653,11 @@ class UcsHandle(UcsSession):
                 dn_set.child_add(dn_obj)
 
             elem = config_resolve_dns(cookie=self.cookie,
-                                                in_dns=dn_set)
+                                      in_dns=dn_set)
             response = self.post_elem(elem)
             if response.error_code != 0:
                 raise UcsException(response.error_code,
-                                      response.error_descr)
+                                   response.error_descr)
 
             for out_mo in response.out_configs.child:
                 out_mo.sync_mo(refresh_dict[out_mo.dn])

--- a/ucsmsdk/ucsmethod.py
+++ b/ucsmsdk/ucsmethod.py
@@ -16,6 +16,10 @@ This module contains the UcsSdk Core classes.
 """
 
 from __future__ import absolute_import
+from .ucscore import UcsBase
+from . import ucscoreutils
+from . import ucsgenutils
+
 
 try:
     import xml.etree.cElementTree as ET
@@ -28,10 +32,6 @@ import logging
 
 log = logging.getLogger('ucs')
 
-
-from .ucscore import UcsBase
-from . import ucscoreutils
-from . import ucsgenutils
 
 class ExternalMethod(UcsBase):
     """
@@ -120,10 +120,11 @@ class ExternalMethod(UcsBase):
         self.child_to_xml(xml_obj, option)
         return xml_obj
 
-    def from_xml(self, elem, handle=None):  # , handle, modify_self=False, mo=None):
+    # , handle, modify_self=False, mo=None):
+    def from_xml(self, elem, handle=None):
         """Method updates/fills the object from the xml representation
         of the external method object. """
-		
+
         self._handle = handle
         if elem.attrib:
             for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -42,6 +42,7 @@ class _GenericProp():
     """
     Internal class to handle the unknown property.
     """
+
     def __init__(self, name, value, is_dirty):
         self.name = name
         self.value = value
@@ -57,7 +58,12 @@ class ManagedObject(UcsBase):
     __internal_prop = frozenset(
         ["_dirty_mask", "_class_id", "_child", "_handle", ''])
 
-    def __init__(self, class_id, parent_mo_or_dn=None, from_xml_response=False, **kwargs):
+    def __init__(
+            self,
+            class_id,
+            parent_mo_or_dn=None,
+            from_xml_response=False,
+            **kwargs):
         self.__parent_mo = None
         self.__status = None
         self.__parent_dn = None
@@ -106,7 +112,6 @@ class ManagedObject(UcsBase):
             self.rn = self.make_rn()
         else:
             self.rn = ""
-
 
     def _dn_set(self):
         """
@@ -171,8 +176,8 @@ class ManagedObject(UcsBase):
             prop_meta = self.prop_meta[name]
             if prop_meta.access != ucscoremeta.MoPropertyMeta.READ_WRITE:
                 if getattr(self, name) is not None or \
-                                prop_meta.access != \
-                                ucscoremeta.MoPropertyMeta.CREATE_ONLY:
+                        prop_meta.access != \
+                        ucscoremeta.MoPropertyMeta.CREATE_ONLY:
                     raise ValueError("%s is not a read-write property." % name)
             if not prop_meta.validate_property_value(value):
                 raise ValueError("Invalid Value Exception - "
@@ -296,8 +301,8 @@ class ManagedObject(UcsBase):
             if key != 'rn' and key in self.prop_meta:
                 mo_prop_meta = self.prop_meta[key]
                 if (option != WriteXmlOption.DIRTY or (
-                            mo_prop_meta.mask is not None and
-                            self._dirty_mask & mo_prop_meta.mask != 0)):
+                    mo_prop_meta.mask is not None and
+                        self._dirty_mask & mo_prop_meta.mask != 0)):
                     value = getattr(self, key)
                     if value is not None:
                         xml_obj.set(mo_prop_meta.xml_attribute, value)
@@ -332,7 +337,8 @@ class ManagedObject(UcsBase):
         self._handle = handle
         if elem.attrib:
             if self.__class__.__name__ != "ManagedObject":
-                for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
+                for attr_name, attr_value in ucsgenutils.iteritems(
+                        elem.attrib):
                     if attr_name in self.prop_map:
                         attr_name = self.prop_map[attr_name]
                     else:
@@ -342,7 +348,8 @@ class ManagedObject(UcsBase):
                             False)
                     object.__setattr__(self, attr_name, attr_value)
             else:
-                for attr_name, attr_value in ucsgenutils.iteritems(elem.attrib):
+                for attr_name, attr_value in ucsgenutils.iteritems(
+                        elem.attrib):
                     object.__setattr__(self, attr_name, attr_value)
 
         if hasattr(self, 'rn') and not hasattr(self, 'dn'):
@@ -358,7 +365,7 @@ class ManagedObject(UcsBase):
                     continue
 
                 if self.__class__.__name__ != "ManagedObject" and (
-                            child_elem.tag in self.mo_meta.field_names):
+                        child_elem.tag in self.mo_meta.field_names):
                     pass
 
                 class_id = ucsgenutils.word_u(child_elem.tag)

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -373,8 +373,8 @@ class UcsSession(object):
         self.__stop_refresh_timer()
 
         elem = aaa_refresh(self.__cookie,
-                              self.__username,
-                              self.__password)
+                           self.__username,
+                           self.__password)
         response = self.post_elem(elem)
         if response.error_code != 0:
             self.__cookie = None
@@ -428,7 +428,7 @@ class UcsSession(object):
             if not self.__force:
                 top_system = TopSystem()
                 elem = config_resolve_dn(cookie=self.__cookie,
-                                            dn=top_system.dn)
+                                         dn=top_system.dn)
                 response = self.post_elem(elem)
                 if response.error_code != 0:
                     return False
@@ -464,7 +464,7 @@ class UcsSession(object):
             return True
 
         elem = aaa_login(in_name=self.__username,
-                            in_password=self.__password)
+                         in_password=self.__password)
         response = self.post_elem(elem)
         if response.error_code != 0:
             self.__clear()
@@ -480,7 +480,7 @@ class UcsSession(object):
             firmware = FirmwareRunning(top_system,
                                        FirmwareRunningConsts.DEPLOYMENT_SYSTEM)
             elem = config_resolve_dn(cookie=self.__cookie,
-                                        dn=firmware.dn)
+                                     dn=firmware.dn)
             response = self.post_elem(elem)
             if response.error_code != 0:
                 raise UcsException(response.error_code,

--- a/ucsmsdk/utils/ccoimage.py
+++ b/ucsmsdk/utils/ccoimage.py
@@ -28,6 +28,7 @@ from ..ucsdriver import UcsDriver
 
 log = logging.getLogger('ucs')
 
+
 class _UcsCcoImageList:
     """enum for cco image attributes"""
     IDAC_TAG_VERSION = "version"

--- a/ucsmsdk/utils/comparesyncmo.py
+++ b/ucsmsdk/utils/comparesyncmo.py
@@ -51,6 +51,7 @@ class _PropDiff(object):
     """
     Internal class for property delta
     """
+
     def __init__(self, prop, old_value, new_value):
         self.prop = prop
         self.old_value = old_value
@@ -537,10 +538,10 @@ def write_mo_diff(diff_obj):
         return
 
     if isinstance(diff_obj[0], _MoDiff):
-        print("dn".ljust(tab_size*10), "input_object".ljust(tab_size*4),
-              "side_indicator".ljust(tab_size*3), "diff_property")
-        print("--".ljust(tab_size*10), "-----------".ljust(tab_size*4),
-              "-------------".ljust(tab_size*3), "------------")
+        print("dn".ljust(tab_size * 10), "input_object".ljust(tab_size * 4),
+              "side_indicator".ljust(tab_size * 3), "diff_property")
+        print("--".ljust(tab_size * 10), "-----------".ljust(tab_size * 4),
+              "-------------".ljust(tab_size * 3), "------------")
     diff_obj_mod = []
     for mo_diff in diff_obj:
         if not isinstance(mo_diff, _MoDiff):
@@ -548,8 +549,8 @@ def write_mo_diff(diff_obj):
         diff_obj_mod.append(mo_diff)
 
     for mo_diff in sorted(diff_obj_mod, key=lambda mo: mo.dn):
-        print(str(mo_diff.dn).ljust(tab_size*10),
-              str(mo_diff.input_object.get_class_id()).ljust(tab_size*4),
-              str(mo_diff.side_indicator).ljust(tab_size*3),
+        print(str(mo_diff.dn).ljust(tab_size * 10),
+              str(mo_diff.input_object.get_class_id()).ljust(tab_size * 4),
+              str(mo_diff.side_indicator).ljust(tab_size * 3),
               str(sorted(mo_diff.diff_property))
               if mo_diff.diff_property else str(mo_diff.diff_property))

--- a/ucsmsdk/utils/converttopython.py
+++ b/ucsmsdk/utils/converttopython.py
@@ -26,15 +26,14 @@ import re
 import xml.dom
 import xml.dom.minidom
 from os.path import dirname
-import logging
-
-log = logging.getLogger('ucs')
-
 from .. import ucsgenutils
 from .. import ucscoreutils
 from ..ucsconstants import Status, NamingPropertyId, YesOrNo
 from ..ucsexception import UcsValidationException
 
+import logging
+
+log = logging.getLogger('ucs')
 
 # variable declaration
 _display_xml = False
@@ -285,8 +284,8 @@ def _create_property_map_from_node(class_node, class_status):
     elif "rn" in attributes_dict:
         prop_rn = attributes_dict["rn"]
 
-    naming_props_py_from_rn = ucscoreutils.get_naming_props(prop_rn,
-                                                        peer_class_mo_meta.rn)
+    naming_props_py_from_rn = ucscoreutils.get_naming_props(
+        prop_rn, peer_class_mo_meta.rn)
 
     for attr, val in class_node.attributes.items():
         name = attr
@@ -371,9 +370,9 @@ def _get_config_conf_cmdlet(node, is_pair_node):
         dn = class_node.getAttribute(NamingPropertyId.DN)
 
     if class_node.hasAttribute(
-            NamingPropertyId.STATUS) and \
-                    class_node.getAttribute(NamingPropertyId.STATUS) is not \
-                    None:
+        NamingPropertyId.STATUS) and \
+            class_node.getAttribute(NamingPropertyId.STATUS) is not \
+            None:
         mo_tag = "mo"
     else:
         if class_node.hasChildNodes() and len(
@@ -393,16 +392,16 @@ def _get_config_conf_cmdlet(node, is_pair_node):
     # print top_cmdlet
 
     if class_node.hasChildNodes() and \
-                    len(_get_elem_child_nodes(class_node)) > 0:
+            len(_get_elem_child_nodes(class_node)) > 0:
         call_count = 1
-        cmdlet=""
+        cmdlet = ""
         for child_node in _get_elem_child_nodes(class_node):
             sub_cmdlet, import_list, obj_flag = _get_config_conf_sub_cmdlet(
-                                                                child_node,
-                                                                dn, mo_tag,
-                                                                call_count,
-                                                                import_list,
-                                                                obj_flag)
+                child_node,
+                dn, mo_tag,
+                call_count,
+                import_list,
+                obj_flag)
 
             call_count += 1
             if sub_cmdlet is not None:
@@ -430,7 +429,7 @@ def _get_config_conf_cmdlet(node, is_pair_node):
     if import_cmdlet:
         main_cmdlet += "\n" + import_cmdlet
     if mo_tag == "obj" and not obj_flag:
-        top_cmdlet=""
+        top_cmdlet = ""
 
     main_cmdlet += "\n" + top_cmdlet
     main_cmdlet += cmdlet
@@ -470,12 +469,12 @@ def _get_config_conf_sub_cmdlet(class_node, parent_dn, parent_mo_tag,
     # Recursively cater to subnodes
     for child_node in _get_elem_child_nodes(class_node):
         sub_cmdlet, import_list, obj_flag = _get_config_conf_sub_cmdlet(
-                                                                  child_node,
-                                                                  dn,
-                                                                  tag,
-                                                                  count,
-                                                                  import_list,
-                                                                  obj_flag)
+            child_node,
+            dn,
+            tag,
+            count,
+            import_list,
+            obj_flag)
         count += 1
         if sub_cmdlet is not None:
             cmdlet += "\n" + sub_cmdlet
@@ -516,9 +515,9 @@ def _form_configconf_cmdlet(class_node, key, tag, import_list, parent_tag=None,
         parent_class_id = ""
 
     if class_node.hasAttribute(
-            NamingPropertyId.STATUS) and \
-                    class_node.getAttribute(NamingPropertyId.STATUS) is not \
-                    None:
+        NamingPropertyId.STATUS) and \
+            class_node.getAttribute(NamingPropertyId.STATUS) is not \
+            None:
         cs_list = []
         cs_list = class_node.getAttribute(NamingPropertyId.STATUS).split(',')
         cs_list = [x.strip() for x in cs_list]
@@ -535,7 +534,7 @@ def _form_configconf_cmdlet(class_node, key, tag, import_list, parent_tag=None,
             class_status = _ClassStatus.CREATED | _ClassStatus.MODIFIED
         else:
             if class_node.hasChildNodes() and \
-                            len(_get_elem_child_nodes(class_node)) > 0:
+                    len(_get_elem_child_nodes(class_node)) > 0:
                 class_status = _ClassStatus.GET
             else:
                 class_status = _ClassStatus.CREATED | _ClassStatus.MODIFIED
@@ -551,8 +550,8 @@ def _form_configconf_cmdlet(class_node, key, tag, import_list, parent_tag=None,
         op_flag = "get"
         cmdlet = "%s = handle.query_dn(\"%s\")" % (tag, key)
     elif class_status & _ClassStatus.DELETED == _ClassStatus.DELETED or \
-                            class_status & \
-                            _ClassStatus.REMOVED == _ClassStatus.REMOVED:
+            class_status & \
+            _ClassStatus.REMOVED == _ClassStatus.REMOVED:
         op_flag = "remove"
         cmdlet = "%s = handle.query_dn(\"%s\")\n" % (tag, key)
     elif class_status & _ClassStatus.CREATED == _ClassStatus.CREATED:
@@ -907,19 +906,19 @@ def _generate_single_clone_cmdlets(xml_string, is_template):
                   'handle.cookie, dn="%s", in_error_on_existing=' \
                   '"%s", in_server_name="%s", in_target_org=' \
                   '"%s", in_hierarchical="%s")' % (dn,
-                                                 in_error_on_existing,
-                                                 sp_new_name,
-                                                 dest_org,
-                                                 in_hierarchical_value)
+                                                   in_error_on_existing,
+                                                   sp_new_name,
+                                                   dest_org,
+                                                   in_hierarchical_value)
         cmdlet += '\nmo_list = handle.process_xml_elem(elem)\n'
     else:
         cmdlet = '\nfrom ucsmsdk.ucsmethodfactory import ls_clone\n'
         cmdlet += 'elem = ls_clone(cookie=handle.cookie, dn=' \
                   '"%s", in_server_name="%s", in_target_org=' \
                   '"%s", in_hierarchical="%s")' % (dn,
-                                                 sp_new_name,
-                                                 dest_org,
-                                                 in_hierarchical_value)
+                                                   sp_new_name,
+                                                   dest_org,
+                                                   in_hierarchical_value)
         cmdlet += '\nmo_list = handle.process_xml_elem(elem)\n'
 
     return cmdlet
@@ -991,10 +990,10 @@ def _generate_ls_templatise_cmdlets(xml_string):
         cmdlet += 'elem = ls_templatise(cookie=handle.cookie,' \
                   'dn="%s", in_target_org="%s", in_template_name="%s", ' \
                   'in_template_type="%s", in_hierarchical="%s")' % (dn,
-                                                      dest_org,
-                                                      sp_new_name,
-                                                      template_type,
-                                                      in_hierarchical_value)
+                                                                    dest_org,
+                                                                    sp_new_name,
+                                                                    template_type,
+                                                                    in_hierarchical_value)
         cmdlet += '\nmo_list = handle.process_xml_elem(elem)\n'
     else:
         cmdlet = '\nfrom ucsmsdk.ucsmethodfactory import ls_templatise\n'

--- a/ucsmsdk/utils/ucsbackup.py
+++ b/ucsmsdk/utils/ucsbackup.py
@@ -178,11 +178,12 @@ def import_ucs_backup(handle, file_dir, file_name, merge=False):
     host_name = "backup." + str(datetime.datetime.now().strftime('%Y%m%d%H%M'))
 
     top_system = TopSystem()
-    mgmt_importer = MgmtImporter(parent_mo_or_dn=top_system,
-                                 hostname=host_name,
-                                 remote_file=file_path,
-                                 proto=MgmtImporterConsts.PROTO_HTTP,
-                            admin_state=MgmtImporterConsts.ADMIN_STATE_ENABLED)
+    mgmt_importer = MgmtImporter(
+        parent_mo_or_dn=top_system,
+        hostname=host_name,
+        remote_file=file_path,
+        proto=MgmtImporterConsts.PROTO_HTTP,
+        admin_state=MgmtImporterConsts.ADMIN_STATE_ENABLED)
 
     if merge:
         mgmt_importer.action = MgmtImporterConsts.ACTION_MERGE

--- a/ucsmsdk/utils/ucskvmlaunch.py
+++ b/ucsmsdk/utils/ucskvmlaunch.py
@@ -79,7 +79,7 @@ def ucs_kvm_launch(handle, service_profile=None, blade=None, rack_unit=None,
 
     if (blade is not None and rack_unit is not None) or \
         (service_profile is not None and rack_unit is not None) or \
-        (blade is not None and service_profile is not None):
+            (blade is not None and service_profile is not None):
         raise UcsValidationException(
             "Provide only one parameter from blade, "
             "rack_unit and service profile.")
@@ -149,7 +149,6 @@ def ucs_kvm_launch(handle, service_profile=None, blade=None, rack_unit=None,
         else:
             sp_mo = handle.query_dn(dn)
 
-
         nvc[_ParamKvm.KVM_DN] = dn
 
         # sp_mo = service_profile
@@ -181,7 +180,7 @@ def ucs_kvm_launch(handle, service_profile=None, blade=None, rack_unit=None,
                     break
 
     if (ip_address is None or ip_address == '0.0.0.0') and \
-        service_profile is not None:
+            service_profile is not None:
 
         elem = config_scope(cookie=handle.cookie,
                             dn=pn_dn,

--- a/ucsmsdk/utils/ucstechsupport.py
+++ b/ucsmsdk/utils/ucstechsupport.py
@@ -149,7 +149,7 @@ def get_ucs_tech_support(handle,
 
     from ..mometa.top.TopSystem import TopSystem
     from ..mometa.sysdebug.SysdebugTechSupport import SysdebugTechSupport, \
-                                                    SysdebugTechSupportConsts
+        SysdebugTechSupportConsts
     from ..mometa.sysdebug.SysdebugTechSupFileRepository import \
         SysdebugTechSupFileRepository
     from ..mometa.sysdebug.SysdebugTechSupportCmdOpt import \
@@ -223,7 +223,7 @@ def get_ucs_tech_support(handle,
     elif fex_id is not None:
         sys_debug_tech_support_cmd_opt.fab_ext_id = str(iom_id)
         sys_debug_tech_support_cmd_opt.major_opt_type = \
-                SysdebugTechSupportCmdOptConsts.MAJOR_OPT_TYPE_FEX
+            SysdebugTechSupportCmdOptConsts.MAJOR_OPT_TYPE_FEX
 
     handle.add_mo(sys_debug_tech_support)
     handle.commit()


### PR DESCRIPTION
PEP8 compliance related fixes

flake8 based counts

The below table shows the counts as they stand for all top level files. Most of the remaining ones are within docstrings, which is ok.

file |  orig | current
--------------------------
ucshandle.py | 23 | 13
ucscore.py | 6 | 0
ucscoreutils.py | 5 |  2
ucsmethod.py | 11 | 2
ucsmo.py | 4 | 0
ucssession.py | 7 | 2
ucsfilter.py | 3 | 1
ucsexception.py | 1 | 0
