### PR TITLE
support for multiple parallel commit buffers + ensure latest cookie usage

### DIFF
--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -532,7 +532,6 @@ class UcsHandle(UcsSession):
 
         self.__commit_buf_tagged[tag][mo.dn] = mo
 
-
     def add_mo(self, mo, modify_present=False, tag=None):
         """
         Adds a managed object to the UcsHandle commit buffer.

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -49,7 +49,8 @@ class UcsHandle(UcsSession):
     def __init__(self, ip, username, password, port=None, secure=None,
                  proxy=None):
         UcsSession.__init__(self, ip, username, password, port, secure, proxy)
-        self.__to_commit = {}
+        self.__commit_buf = {}
+        self.__commit_buf_tagged = {}
 
     def set_dump_xml(self):
         """
@@ -516,7 +517,23 @@ class UcsHandle(UcsSession):
 
         return out_mo_list
 
-    def add_mo(self, mo, modify_present=False):
+    def _get_commit_buf(self, tag=None):
+        if tag is None:
+            return self.__commit_buf
+        return self.__commit_buf_tagged[tag]
+
+    def _update_commit_buf(self, mo, tag=None):
+        if tag is None:
+            self.__commit_buf[mo.dn] = mo
+            return
+
+        if tag not in self.__commit_buf_tagged:
+            self.__commit_buf_tagged[tag] = {}
+
+        self.__commit_buf_tagged[tag][mo.dn] = mo
+
+
+    def add_mo(self, mo, modify_present=False, tag=None):
         """
         Adds a managed object to the UcsHandle commit buffer.
         This method does not trigger a commit by itself.
@@ -541,9 +558,9 @@ class UcsHandle(UcsSession):
         else:
             mo.status = "created"
 
-        self.__to_commit[mo.dn] = mo
+        self._update_commit_buf(mo, tag)
 
-    def set_mo(self, mo):
+    def set_mo(self, mo, tag=None):
         """
         Modifies a managed object and adds it to UcsHandle commit buffer (if
          not already in it).
@@ -564,9 +581,9 @@ class UcsHandle(UcsSession):
         """
 
         mo.status = "modified"
-        self.__to_commit[mo.dn] = mo
+        self._update_commit_buf(mo, tag)
 
-    def remove_mo(self, mo):
+    def remove_mo(self, mo, tag=None):
         """
         Removes a managed object.
         This method does not trigger a commit by itself.
@@ -589,9 +606,9 @@ class UcsHandle(UcsSession):
         if mo.parent_mo:
             mo.parent_mo.child_remove(mo)
 
-        self.__to_commit[mo.dn] = mo
+        self._update_commit_buf(mo, tag)
 
-    def commit(self):
+    def commit(self, tag=None):
         """
         Commit the buffer to the server. Pushes all the configuration changes
         so far to the server.
@@ -613,7 +630,7 @@ class UcsHandle(UcsSession):
         from .ucsmethodfactory import config_conf_mos
 
         refresh_dict = {}
-        mo_dict = self.__to_commit
+        mo_dict = self._get_commit_buf(tag)
         if not mo_dict:
             log.debug("Commit Buffer is Empty")
             return None
@@ -639,7 +656,7 @@ class UcsHandle(UcsSession):
                                False)
         response = self.post_elem(elem)
         if response.error_code != 0:
-            self.commit_buffer_discard()
+            self.commit_buffer_discard(tag)
             raise UcsException(response.error_code, response.error_descr)
 
         for pair_ in response.out_configs.child:
@@ -663,9 +680,9 @@ class UcsHandle(UcsSession):
             for out_mo in response.out_configs.child:
                 out_mo.sync_mo(refresh_dict[out_mo.dn])
 
-        self.commit_buffer_discard()
+        self.commit_buffer_discard(tag)
 
-    def commit_buffer_discard(self):
+    def commit_buffer_discard(self, tag=None):
         """
         Discard the configuration changes in the commit buffer.
 
@@ -678,5 +695,8 @@ class UcsHandle(UcsSession):
         Example:
             handle.commit_buffer_discard()
         """
+        if tag is None:
+            self.__commit_buf = {}
 
-        self.__to_commit = {}
+        if tag in self.__commit_buf_tagged:
+            del self.__commit_buf_tagged[tag]

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -277,6 +277,13 @@ class UcsSession(object):
 
         if response_str:
             response = xc.from_xml_str(response_str, self)
+
+            # Cookie update should happen with-in the lock
+            # this ensures that the next packet goes out
+            # with the new cookie
+            if elem.tag == "aaaRefresh":
+                self._update_cookie(response)
+
             tx_lock.release()
             return response
 
@@ -370,6 +377,11 @@ class UcsSession(object):
         if self.__refresh_timer is not None:
             self.__refresh_timer.cancel()
             self.__refresh_timer = None
+
+    def _update_cookie(self, response):
+        if response.error_code != 0:
+            return
+        self.__cookie = response.out_cookie
 
     def _refresh(self, auto_relogin=False):
         """

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -255,7 +255,6 @@ class UcsSession(object):
         tx_lock.acquire()
         # check if the cookie is latest
         if 'cookie' in elem.attrib and elem.attrib['cookie'] != "" and elem.attrib['cookie'] != self.cookie:
-            log.info("updating cookie.. old " + elem.attrib['cookie'] + " new " + self.cookie)
             elem.attrib['cookie'] = self.cookie
 
         dump_xml = self.__dump_xml


### PR DESCRIPTION
This PR adds support for using multiple parallel tagged commit buffers. The tag needs to be supplied by the application using the sdk. This could be thread name or anything else. Expectation is one tag name per thread.

add, set, remove and commit now also take a `tag` argument.. This is used to carve out a separate buffer space for this `tag`. Thus we can support multiple parallel transactions now. 

usage:
`handle.add_mo(mo1, tag="thread1")`
`handle.add_mo(mo2, tag="thread2")`
`handle.add_mo(mo3, tag="thread1")`
`handle.add_mo(mo4, tag="thread2")`
`handle.commit(tag="thread1")`
`handle.add_mo(mo5, tag="thread2")`
`handle.commit(tag="thread2")`

This PR also ensures that we always use the latest cookie after a `aaaRefresh` or reLogin. Additionally we also lock `post_elem` to make sure that the driver works serially, while the application works in parallel.

