### PR TITLE
Added method to convert managed object to json format

### DIFF
--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -216,6 +216,38 @@ class ManagedObject(UcsBase):
         out_str += "\n"
         return out_str
 
+    def to_dict(self, include_children=True, depth=None, level=0):
+        mo_dict = {self._class_id: None}
+
+        prop_dict = {}
+        for prop, prop_value in sorted(ucsgenutils.iteritems(self.__dict__)):
+            if prop in ManagedObject.__internal_prop or prop.startswith(
+                    "_ManagedObject__"):
+                continue
+            prop_dict[prop] = prop_value
+
+        if not self._child or not include_children:
+            mo_dict[self._class_id] = prop_dict
+            return mo_dict
+
+        level += 1
+        if depth is None or level < depth:
+            prop_dict['child'] = []
+            for ch in self._child:
+                prop_dict['child'].append(ch.to_dict(include_children,
+                                                     depth,
+                                                     level))
+
+        mo_dict[self._class_id] = prop_dict
+        return mo_dict
+
+    def to_json(self, include_children=True, depth=None):
+        import json
+
+        return json.dumps(self.to_dict(include_children, depth),
+                          indent=2,
+                          sort_keys=True)
+
     def mark_dirty(self):
         """
         This method marks the managed object dirty.
@@ -665,3 +697,34 @@ class GenericMo(UcsBase):
                 out_str += str(prop).ljust(ts * 4) + ':' + str(prop_val) + "\n"
 
             return out_str
+
+    def to_dict(self, include_children=True, depth=None, level=0):
+        mo_dict = {self._class_id: None}
+
+        prop_dict = {}
+        for prop, prop_value in sorted(ucsgenutils.iteritems(self.__dict__)):
+            if prop.startswith('_'):
+                continue
+            prop_dict[prop] = prop_value
+
+        if not self._child or not include_children:
+            mo_dict[self._class_id] = prop_dict
+            return mo_dict
+
+        level += 1
+        if depth is None or level < depth:
+            prop_dict['child'] = []
+            for ch in self._child:
+                prop_dict['child'].append(ch.to_dict(include_children,
+                                                     depth,
+                                                     level))
+
+        mo_dict[self._class_id] = prop_dict
+        return mo_dict
+
+    def to_json(self, include_children=True, depth=None):
+        import json
+
+        return json.dumps(self.to_dict(include_children, depth),
+                          indent=2,
+                          sort_keys=True)


### PR DESCRIPTION
```
org = OrgOrg("org-root", name="org")
sp = LsServer(org, name="sp")
org_json = org.to_json(depth=1)
print(org_json)

{
  "OrgOrg": {
    "child_action": null,
    "descr": null,
    "dn": "org-root/org-org",
    "flt_aggr": null,
    "level": null,
    "name": "org",
    "perm_access": null,
    "rn": "org-org",
    "sacl": null,
    "status": null
  }
}```


```
org = OrgOrg("org-root", name="org")
sp = LsServer(org, name="sp")
org_json = org.to_json()
print(org_json)

{
  "OrgOrg": {
    "child": [
      {
        "LsServer": {
          "agent_policy_name": null,
          "assign_state": null,
          "assoc_state": null,
          "bios_profile_name": null,
          "boot_policy_name": null,
          "child_action": null,
          "config_qualifier": null,
          "config_state": null,
          "descr": null,
          "dn": "org-root/org-org/ls-sp",
          "dynamic_con_policy_name": null,
          "ext_ip_pool_name": null,
          "ext_ip_state": null,
          "flt_aggr": null,
          "fsm_descr": null,
          "fsm_flags": null,
          "fsm_prev": null,
          "fsm_progr": null,
          "fsm_rmt_inv_err_code": null,
          "fsm_rmt_inv_err_descr": null,
          "fsm_rmt_inv_rslt": null,
          "fsm_stage_descr": null,
          "fsm_stamp": null,
          "fsm_status": null,
          "fsm_try": null,
          "host_fw_policy_name": null,
          "ident_pool_name": null,
          "int_id": null,
          "kvm_mgmt_policy_name": null,
          "local_disk_policy_name": null,
          "maint_policy_name": null,
          "mgmt_access_policy_name": null,
          "mgmt_fw_policy_name": null,
          "name": "sp",
          "oper_bios_profile_name": null,
          "oper_boot_policy_name": null,
          "oper_dynamic_con_policy_name": null,
          "oper_ext_ip_pool_name": null,
          "oper_host_fw_policy_name": null,
          "oper_ident_pool_name": null,
          "oper_kvm_mgmt_policy_name": null,
          "oper_local_disk_policy_name": null,
          "oper_maint_policy_name": null,
          "oper_mgmt_access_policy_name": null,
          "oper_mgmt_fw_policy_name": null,
          "oper_power_policy_name": null,
          "oper_power_sync_policy_name": null,
          "oper_scrub_policy_name": null,
          "oper_sol_policy_name": null,
          "oper_src_templ_name": null,
          "oper_state": null,
          "oper_stats_policy_name": null,
          "oper_vcon_profile_name": null,
          "oper_vmedia_policy_name": null,
          "owner": null,
          "pn_dn": null,
          "policy_level": null,
          "policy_owner": null,
          "power_policy_name": null,
          "power_sync_policy_name": null,
          "prop_acl": null,
          "resolve_remote": null,
          "rn": "ls-sp",
          "sacl": null,
          "scrub_policy_name": null,
          "sol_policy_name": null,
          "src_templ_name": null,
          "stats_policy_name": null,
          "status": null,
          "svnic_config": null,
          "type": null,
          "usr_lbl": null,
          "uuid": null,
          "uuid_suffix": null,
          "vcon_profile_name": null,
          "vmedia_policy_name": null
        }
      }
    ],
    "child_action": null,
    "descr": null,
    "dn": "org-root/org-org",
    "flt_aggr": null,
    "level": null,
    "name": "org",
    "perm_access": null,
    "rn": "org-org",
    "sacl": null,
    "status": null
  }
}```