### PR TITLE
Added both the properties in jnlp file independent of java version

### DIFF
--- a/ucsmsdk/ucsgenutils.py
+++ b/ucsmsdk/ucsgenutils.py
@@ -226,17 +226,21 @@ def upload_file(driver, uri, file_dir, file_name, progress=Progress()):
 
 def check_registry_key(java_key):
     """ Method checks for the java in the registry entries. """
+
+    # Added KEY_WOW64_64KEY, KEY_ALL_ACCESS. This lets 32bit python access
+    # registry keys of 64bit Application on Windows supporting 64 bit.
+
     try:
         from _winreg import ConnectRegistry, HKEY_LOCAL_MACHINE, OpenKey, \
-            QueryValueEx
+            QueryValueEx, KEY_WOW64_64KEY, KEY_ALL_ACCESS
     except:
         from winreg import ConnectRegistry, HKEY_LOCAL_MACHINE, OpenKey, \
-            QueryValueEx
+            QueryValueEx, KEY_WOW64_64KEY, KEY_ALL_ACCESS
 
     path = None
     try:
         a_reg = ConnectRegistry(None, HKEY_LOCAL_MACHINE)
-        r_key = OpenKey(a_reg, java_key)
+        r_key = OpenKey(a_reg, java_key, 0, KEY_WOW64_64KEY + KEY_ALL_ACCESS)
         for i_cnt in range(1024):
             current_version = QueryValueEx(r_key, "CurrentVersion")
             if current_version is not None:

--- a/ucsmsdk/utils/ucsguilaunch.py
+++ b/ucsmsdk/utils/ucsguilaunch.py
@@ -85,30 +85,26 @@ def ucs_gui_launch(handle, need_url=False):
 
                 java_str = ucsgenutils.get_java_version()
                 log.debug("Java Version: <%s>" % java_str)
-                if re.match(r'1.8', java_str):
-                    debug_str = '\t<property ' \
-                                    'name="jnlp.ucsm.log.show.encrypted" ' \
-                                    'value="true"/>'
-                elif re.match(r'1.7', java_str):
-                    if int(java_str.rsplit('_')[1]) >= 45:
-                        debug_str = '\t<property ' \
-                                    'name="jnlp.ucsm.log.show.encrypted" ' \
-                                    'value="true"/>'
-                    else:
-                        debug_str = '\t<property ' \
-                                    'name="log.show.encrypted" ' \
-                                    'value="true"/>'
-                else:
-                    debug_str = '\t<property ' \
-                                'name="log.show.encrypted" ' \
+
+                # Adding both the property to enable the secure log in UCSM
+                # independent of java versions.
+                # if java version < 1.7_45, property to use is
+                # "log.show.encrypted"
+                # if java version >= 1.7_45, property to use is
+                # "jnlp.ucsm.log.show.encrypted"
+
+                debug_str_old_java = '\t<property ' \
+                            'name="log.show.encrypted" ' \
+                            'value="true"/>'
+
+                debug_str_new_java = '\t<property ' \
+                                'name="jnlp.ucsm.log.show.encrypted" ' \
                                 'value="true"/>'
 
-                log.debug("Enable Log String is %s." % debug_str)
                 for line in fileinput.input(jnlp_file, inplace=1):
                     if re.search(r'^\s*</resources>\s*$', line):
-                        # print debug_str
-                        print(debug_str)
-                    # print line,
+                        print(debug_str_old_java)
+                        print(debug_str_new_java)
                     line = line.strip('\n') if line else line
                     print(line)
                 subprocess.call([javaws_path, jnlp_file])


### PR DESCRIPTION
Modified utility `ucs_gui_launch` to add both the properties in jnlp file to enable secure logs, independent of java version.