### PR TITLE
event handler fixes

### DIFF
--- a/ucsmsdk/ucseventhandler.py
+++ b/ucsmsdk/ucseventhandler.py
@@ -226,6 +226,13 @@ class UcsEventHandle(object):
             return True
         return False
 
+    def _invoke_callback_and_set_done(wb, mce):
+        if wb.callback:
+            ctxt = wb.params['context']
+            if ctxt:
+                ctxt["done"] = True
+            wb.callback(mce)
+
     def __dequeue_mo_prop_poll(self, mo, prop, poll_sec, watch_block,
                                timeout_sec=None, time_left=None):
 
@@ -250,11 +257,8 @@ class UcsEventHandle(object):
 
         if self.__prop_val_exist(pmo, prop, success_value,
                                  failure_value, transient_value):
-            if watch_block.callback:
-                ctxt = watch_block.params['context']
-                if ctxt:
-                    ctxt["done"] = True
-                watch_block.callback(pmo)
+            mce = MoChangeEvent(mo=pmo)
+            self._invoke_callback_and_set_done(watch_block, mce)
             self.__wb_to_remove.append(watch_block)
 
     def __dequeue_mo_prop_event(self, prop, watch_block, time_left=None):
@@ -275,11 +279,7 @@ class UcsEventHandle(object):
         attributes = mce.change_list
         if self.__prop_val_exist(mce.mo, prop, success_value, failure_value,
                                  transient_value, attributes):
-            if watch_block.callback:
-                ctxt = watch_block.params['context']
-                if ctxt:
-                    ctxt["done"] = True
-                watch_block.callback(mce)
+            self._invoke_callback_and_set_done(watch_block, mce)
             self.__wb_to_remove.append(watch_block)
 
     def __dequeue_mo_until_removed(self, watch_block, time_left=None):

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -754,7 +754,7 @@ class UcsHandle(UcsSession):
         if tag in self.__commit_buf_tagged:
             del self.__commit_buf_tagged[tag]
 
-    def wait_for_event(self, mo, prop, value, cb, timeout=None):
+    def wait_for_event(self, mo, prop, value, cb, timeout=None, poll_sec=None):
         """
         Waits for `mo.prop == value` and invokes the passed callback
         when the condition is met. The callback is called with one
@@ -766,6 +766,7 @@ class UcsHandle(UcsSession):
             value (str): property value to wait for
             cb(function): callback on success
             timeout (int): timeout
+            poll_sec (int): polling interval in seconds
 
         Returns:
             None
@@ -776,7 +777,7 @@ class UcsHandle(UcsSession):
 
             sp_mo = handle.query_dn("org-root/ls-demoSP")
             wait_for_event(sp_mo, 'descr', 'demo_description', cb)
-    """
+        """
         from ucseventhandler import wait
 
-        wait(self, mo, prop, value, cb, timeout_sec=timeout)
+        wait(self, mo, prop, value, cb, timeout_sec=timeout, poll_sec=poll_sec)


### PR DESCRIPTION
1. abstracted out `poll_mode` via `wait_for_event`.
1. bug fix when python property names used have `_` in them. It would have worked for `descr` earlier but failed for `usr_lbl`(ucs_prop=usrLbl)
1. callback was not getting involved in poll_mode
1. rename `n_prop` to `ucs_prop`