### PR TITLE
Ignore None Property Value, which causes Exception while Validating

### DIFF
--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -110,7 +110,6 @@ class ManagedObject(UcsBase):
     def _is_unknown_property(self, prop):
         return prop not in self.prop_meta
 
-
     @property
     def parent_mo(self):
         """Getter method of ManagedObject Class"""

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -104,9 +104,6 @@ class ManagedObject(UcsBase):
                 if prop_value is not None:
                     self.__set_prop(prop_name, prop_value)
 
-    def _is_known_property(self, prop):
-        return prop in self.prop_meta
-
     def _is_unknown_property(self, prop):
         return prop not in self.prop_meta
 

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -70,32 +70,46 @@ class ManagedObject(UcsBase):
         self.__xtra_props = {}
         self.__xtra_props_dirty_mask = 0x1
 
-        if parent_mo_or_dn:
-            if isinstance(parent_mo_or_dn, ManagedObject):
-                self.__parent_mo = parent_mo_or_dn
-                self.__parent_dn = self.__parent_mo.dn
-            elif isinstance(parent_mo_or_dn, str):
-                self.__parent_dn = parent_mo_or_dn
-            else:
-                raise ValueError('parent mo or dn must be specified')
+        self._set_parent_mo_or_dn(parent_mo_or_dn)
 
-        if not from_xml_response:
-            self._rn_set()
-            self._dn_set()
+        self._rn_set(from_xml_response)
+        self._dn_set(from_xml_response)
 
-        xml_attribute = self.mo_meta.xml_attribute
+        UcsBase.__init__(self, ucsgenutils.word_u(self.mo_meta.xml_attribute))
 
-        UcsBase.__init__(self, ucsgenutils.word_u(xml_attribute))
-        # self.mark_dirty()
+        self._set_child_of_parent_mo()
+        self._set_mo_prop_value(kwargs)
 
+    def _set_parent_mo_or_dn(self, parent_mo_or_dn):
+        if not parent_mo_or_dn:
+            return
+
+        if isinstance(parent_mo_or_dn, ManagedObject):
+            self.__parent_mo = parent_mo_or_dn
+            self.__parent_dn = parent_mo_or_dn.dn
+        elif isinstance(parent_mo_or_dn, str):
+            self.__parent_dn = parent_mo_or_dn
+        else:
+            raise ValueError('parent mo or dn must be specified')
+
+    def _set_child_of_parent_mo(self):
         if self.__parent_mo:
             self.__parent_mo.child_add(self)
 
+    def _set_mo_prop_value(self, kwargs):
         if kwargs:
             for prop_name, prop_value in ucsgenutils.iteritems(kwargs):
-                if prop_name not in self.prop_meta:
+                if self._is_unknown_property(prop_name):
                     log.debug("Unknown property %s" % prop_name)
-                self.__set_prop(prop_name, prop_value)
+                if prop_value is not None:
+                    self.__set_prop(prop_name, prop_value)
+
+    def _is_known_property(self, prop):
+        return prop in self.prop_meta
+
+    def _is_unknown_property(self, prop):
+        return prop not in self.prop_meta
+
 
     @property
     def parent_mo(self):
@@ -103,20 +117,26 @@ class ManagedObject(UcsBase):
 
         return self.__parent_mo
 
-    def _rn_set(self):
+    def _rn_set(self, from_xml_response=False):
         """
         Internal method to set rn
         """
+
+        if from_xml_response:
+            return
 
         if "prop_meta" in dir(self) and "rn" in self.prop_meta:
             self.rn = self.make_rn()
         else:
             self.rn = ""
 
-    def _dn_set(self):
+    def _dn_set(self, from_xml_response=False):
         """
         Internal method to set dn
         """
+
+        if from_xml_response:
+            return
 
         if "prop_meta" in dir(self) and "dn" in self.prop_meta:
             if self.__parent_dn:


### PR DESCRIPTION

This PR ignores the `None` property values. This will resolve the below type of exceptions.
There is a use case where application passes some params and makes the rest None(the one it does not want to be set).

```
Error message: Invalid Value Exception - [VnicLanConnTempl]: Prop <pin_to_group_name>, Value<None>. 
```

Also did some refactoring to reduce Cyclomatic complexity