### PR TITLE
check for AttributeError exception

### DIFF
--- a/ucsmsdk/utils/ucstechsupport.py
+++ b/ucsmsdk/utils/ucstechsupport.py
@@ -191,6 +191,10 @@ def poll_wait_for_tech_support(handle, ts_mo, timeout):
             if duration == 0:
                 _fail_and_remove_ts(
                     handle, ts, 'TechSupport creation timed out')
+        except AttributeError as err:
+            raise UcsValidationException(
+                "Please check the validity of the input parameters. " \
+                "Please also check for free space in bootflash.")
         except Exception as err:
             _check_for_failure(err)
 


### PR DESCRIPTION
Check for AttributeError exception which is raised when input params are invalid or the system is running low on memory
Signed-off-by: Swapnil Wagh <waghswapnil@gmail.com>