### PR TITLE
fixing event hanlder timeout when there is no enqueue event

### DIFF
--- a/tests/utils/test_eventhandler.py
+++ b/tests/utils/test_eventhandler.py
@@ -210,3 +210,14 @@ def test_wait_for_poll_multiple():
     t3.join()
 
     assert_equal(finished, True)
+
+def test_wait_for_event_timeout_noenqueue():
+
+    handle.wait_for_event(
+        mo=sp,
+        prop="usr_lbl",
+        value="trigger",
+        cb=user_callback,
+        timeout=5
+    )
+

--- a/ucsmsdk/ucseventhandler.py
+++ b/ucsmsdk/ucseventhandler.py
@@ -363,6 +363,11 @@ class UcsEventHandle(object):
                         if time_left <= 0:
                             self._wb_to_remove.append(watch_block)
                             continue
+                    if self._lowest_timeout is None:
+                        self._lowest_timeout = time_left
+                    elif self._lowest_timeout < time_left:
+                        self._lowest_timeout = time_left
+
 
                     # Dequeue any change events for a specified watch_block
                     # poll for mo. Not to monitor event.

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -777,6 +777,6 @@ class UcsHandle(UcsSession):
             sp_mo = handle.query_dn("org-root/ls-demoSP")
             wait_for_event(sp_mo, 'descr', 'demo_description', cb)
         """
-        from ucseventhandler import wait
+        from .ucseventhandler import wait
 
         wait(self, mo, prop, value, cb, timeout_sec=timeout, poll_sec=poll_sec)

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -166,7 +166,7 @@ class UcsSession(object):
         self.__cookie = response.out_cookie
         self.__session_id = response.out_session_id
         self.__version = UcsVersion(response.out_version)
-        self.__refresh_period = response.out_refresh_period
+        self.__refresh_period = int(response.out_refresh_period)
         self.__priv = response.out_priv
         self.__domains = response.out_domains
         self.__channel = response.out_channel


### PR DESCRIPTION
- Fixes an issue where eventhandle timeout is not triggered when there are no incoming events.
- Adds tests for the above
- Fixes some code that wasn't python3 compatible.