### PR TITLE
Output files for csv and html should be open as a textfile as done fo…

### DIFF
--- a/ucsmsdk/utils/inventory.py
+++ b/ucsmsdk/utils/inventory.py
@@ -276,7 +276,7 @@ def _get_inventory_csv(inventory, file_name, spec=inventory_spec):
     if file_name is None:
         raise UcsOperationError("Inventory collection",
                                 "file_name is a required parameter")
-    f = csv.writer(open(file_name, "wb"))
+    f = csv.writer(open(file_name, "w"))
 
     x = inventory
     for comp in spec:
@@ -351,7 +351,7 @@ def _get_inventory_html(inventory, file_name, spec=inventory_spec):
     if file_name is None:
         raise UcsOperationError("Inventory collection",
                                 "file_name is a required parameter")
-    f = open(file_name, "wb")
+    f = open(file_name, "w")
 
     html = ""
     html += "<html>\n"


### PR DESCRIPTION
Output files for csv and html should be open as a textfile as done for json

when files opened in binary mode, I got this error on Windows 

    _get_inventory_html(inventory=inventory, file_name=file_name, spec=spec)
  File "C:\Users\fbonneau\AppData\Local\Programs\Python\Python35-32\lib\site-packages\ucsmsdk\utils\inventory.py", line 405, in _get_inventory_html
    f.write(html)
TypeError: a bytes-like object is required, not 'str' 



