### PR TITLE
Fix in unfreeze, not checking the 'None' value of property and escaping newline from response xml

### DIFF
--- a/ucsmsdk/ucsgenutils.py
+++ b/ucsmsdk/ucsgenutils.py
@@ -519,6 +519,8 @@ def iteritems(d):
     except AttributeError:
         return d.items()
 
+def add_escape_chars(xml_str):
+    return xml_str.replace("\n", "&#xA;")
 
 def remove_invalid_chars(xml_str):
     replace_dict = {

--- a/ucsmsdk/ucsmo.py
+++ b/ucsmsdk/ucsmo.py
@@ -114,7 +114,8 @@ class ManagedObject(UcsBase):
                                  "Class [%s]: Prop <%s> "
                                  % (self.__class__.__name__, prop_name))
 
-            if kwargs[prop_name] != getattr(self, prop_name):
+            if kwargs[prop_name] is not None and \
+                    kwargs[prop_name] != getattr(self, prop_name):
                 return False
         return True
 
@@ -216,7 +217,7 @@ class ManagedObject(UcsBase):
                         prop_meta.access != \
                         ucscoremeta.MoPropertyMeta.CREATE_ONLY:
                     raise ValueError("%s is not a read-write property." % name)
-            if not prop_meta.validate_property_value(value):
+            if value and not prop_meta.validate_property_value(value):
                 raise ValueError("Invalid Value Exception - "
                                  "[%s]: Prop <%s>, Value<%s>. "
                                  % (self.__class__.__name__,

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -161,8 +161,9 @@ class UcsSession(object):
         self.__driver = UcsDriver(proxy=self.__proxy)
 
         # cookie might be stale, if so relogin
-        if self.__auto_refresh:
+        if self.__auto_refresh and not self.__validate_connection():
             self._refresh(auto_relogin=True)
+            self.__auto_refresh = True
 
     def __create_uri(self, port, secure):
         """

--- a/ucsmsdk/ucsxmlcodec.py
+++ b/ucsmsdk/ucsxmlcodec.py
@@ -82,7 +82,8 @@ def from_xml_str(xml_str, handle=None):
     """
 
     try:
-        root_elem = ET.fromstring(xml_str)
+        xml_raw_str = ucsgenutils.add_escape_chars(xml_str)
+        root_elem = ET.fromstring(xml_raw_str)
     except:
         recovered_xml = ucsgenutils.remove_invalid_chars(xml_str)
         root_elem = ET.fromstring(recovered_xml)


### PR DESCRIPTION
It contains 3 fixes:

* Fix in unfreeze for validate connection in case cookie is stale
* Skip checking 'None' values for validation
* Escaping new-line character in response xml.

Signed-off-by: Parag Shah <paragsh@cisco.com>