### PR TITLE
Fix UcsVersion comparison working backwards

### DIFF
--- a/ucsmsdk/ucscoremeta.py
+++ b/ucsmsdk/ucscoremeta.py
@@ -108,12 +108,12 @@ class UcsVersion(object):
             return 1
 
         if self.__major != version.major:
-            return ord(self.__major) - ord(version.major)
+            return ord(version.major) - ord(self.__major)
         if self.__minor != version.minor:
-            return ord(self.__minor) - ord(version.major)
+            return ord(version.major) - ord(self.__minor)
         if self.__mr != version.mr:
-            return ord(self.__mr) - ord(version.mr)
-        return ord(self.__patch) - ord(version.patch)
+            return ord(version.mr) - ord(self.__mr)
+        return ord(version.patch) - ord(self.__patch)
 
     def __gt__(self, version):
         return self.compare_to(version) > 0


### PR DESCRIPTION
The UcsVersion comparison methods seem to work backwards, as you can see below:

from ucsmsdk.ucscoremeta import UcsVersion
toto = UcsVersion("3.1(3a)")
titi = UcsVersion("3.2(1d)")
titi.__gt__(toto)
False

When it should report that "titi" is indeed 'greater than' "toto", as 3.2(1d) > 3.1(3a).


Reversing the calculations in the methods solves the issue:
>>> from ucsmsdk.ucscoremeta import UcsVersion
>>> toto = UcsVersion("3.1(3a)")
>>> titi = UcsVersion("3.2(1d)")
>>> titi.__gt__(toto)
True 