### PR TITLE
Fix UcsVersion comparison works backwards

### DIFF
--- a/ucsmsdk/ucscoremeta.py
+++ b/ucsmsdk/ucscoremeta.py
@@ -110,7 +110,7 @@ class UcsVersion(object):
         if self.__major != version.major:
             return ord(self.__major) - ord(version.major)
         if self.__minor != version.minor:
-            return ord(self.__minor) - ord(version.major)
+            return ord(self.__minor) - ord(version.minor)
         if self.__mr != version.mr:
             return ord(self.__mr) - ord(version.mr)
         return ord(self.__patch) - ord(version.patch)


### PR DESCRIPTION
The UcsVersion comparison works backwards for minor revisions, because of a typo