### PR TITLE
Fix to run UTs without valid UCSM

### DIFF
--- a/tests/common/test_request_xml.py
+++ b/tests/common/test_request_xml.py
@@ -13,8 +13,9 @@
 
 from __future__ import print_function
 
+from nose import SkipTest
 from nose.tools import *
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 
@@ -22,6 +23,9 @@ handle = None
 def setup():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown():

--- a/tests/common/test_serialization.py
+++ b/tests/common/test_serialization.py
@@ -11,12 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..connection.info import custom_setup, custom_teardown
+from nose import SkipTest
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 from ucsmsdk.ucshandle import UcsHandle
 
 
 def test_serialize_handle():
     handle1 = custom_setup()
+    if not handle1:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
+
     frozen_handle = handle1.freeze()
     handle2 = UcsHandle.unfreeze(frozen_handle)
     custom_teardown(handle2)

--- a/tests/common/test_threadedmode.py
+++ b/tests/common/test_threadedmode.py
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import with_setup, assert_equal
 import threading
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 
@@ -21,6 +22,9 @@ handle = None
 def setup_module():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown_module():

--- a/tests/common/test_ucspropval.py
+++ b/tests/common/test_ucspropval.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import *
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 obj = None
@@ -24,6 +25,10 @@ def setup_module():
     global handle
 
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
+
     obj = LsServer("org-root", "test", usr_lbl="sample")
 
     handle.add_mo(obj, True)
@@ -31,8 +36,9 @@ def setup_module():
 
 
 def teardown_module():
-    handle.remove_mo(obj)
-    handle.commit()
+    if handle:
+        handle.remove_mo(obj)
+        handle.commit()
     custom_teardown(handle)
 
 

--- a/tests/connection/connection.cfg
+++ b/tests/connection/connection.cfg
@@ -1,4 +1,10 @@
 [ucs]
-hostname=192.168.1.1
-username=admin
-password=password
+# To run Unit Tests against a valid UCSM domain, provide
+# the following configuration parameters in the format
+# specified below.
+# Note: Not providing these parameters will skip tests
+# that depend on connecting to a valid UCSM domain.
+
+#hostname=192.168.1.1
+#username=admin
+#password=password

--- a/tests/connection/info.py
+++ b/tests/connection/info.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 host = "ucs"
-
+skip_msg = "Not connected to a valid UCSM domain."
 
 def custom_setup():
     try:
@@ -26,14 +26,20 @@ def custom_setup():
     config = ConfigParser.RawConfigParser()
     config.read(os.path.join(os.path.dirname(__file__), '..', 'connection',
                              'connection.cfg'))
-
-    hostname = config.get(host, "hostname")
-    username = config.get(host, "username")
-    password = config.get(host, "password")
+    try:
+        hostname = config.get(host, "hostname")
+        username = config.get(host, "username")
+        password = config.get(host, "password")
+    except:
+        return None
     handle = UcsHandle(hostname, username, password)
     handle.login(auto_refresh=True, force=True)
     return handle
 
 
 def custom_teardown(handle):
-    handle.logout()
+    if handle:
+        handle.logout()
+
+def get_skip_msg():
+    return skip_msg

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import with_setup
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 
@@ -20,6 +21,9 @@ handle = None
 def setup():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown():

--- a/tests/sp/test_sp.py
+++ b/tests/sp/test_sp.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import with_setup
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 
@@ -20,6 +21,9 @@ handle = None
 def setup():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown():

--- a/tests/utils/test_backupucs.py
+++ b/tests/utils/test_backupucs.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import with_setup
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 from ucsmsdk.utils.ucsbackup import backup_ucs
 from ucsmsdk.ucshandle import UcsHandle
 
@@ -22,6 +23,9 @@ handle = None
 def setup_module():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown_module():

--- a/tests/utils/test_eventhandler.py
+++ b/tests/utils/test_eventhandler.py
@@ -13,8 +13,9 @@
 
 import time
 
+from nose import SkipTest
 from nose.tools import *
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 import threading
 
 handle = None
@@ -29,6 +30,9 @@ def setup_module():
 
     global handle, sp, ueh
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
     ueh = UcsEventHandle(handle)
     org = handle.query_dn("org-root")
 

--- a/tests/vlan/tests_vlan.py
+++ b/tests/vlan/tests_vlan.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nose import SkipTest
 from nose.tools import with_setup
-from ..connection.info import custom_setup, custom_teardown
+from ..connection.info import custom_setup, custom_teardown, get_skip_msg
 
 handle = None
 
@@ -20,6 +21,9 @@ handle = None
 def setup():
     global handle
     handle = custom_setup()
+    if not handle:
+        msg = get_skip_msg()
+        raise SkipTest(msg)
 
 
 def teardown():


### PR DESCRIPTION
The following changes allow the UTs to skip tests that require a connection to a valid UCSM domain.