### PR TITLE
Fix Python3 incompatibility (TypeError)

### DIFF
--- a/ucsmsdk/ucsxmlcodec.py
+++ b/ucsmsdk/ucsxmlcodec.py
@@ -37,7 +37,7 @@ def to_xml_str(elem):
         xml_str = to_xml_str(elem=xml_element)
     """
 
-    return ET.tostring(elem).replace("&#10;", "\n")
+    return ET.tostring(elem).replace(b'&#10;', b'\n')
 
 
 def extract_root_elem(xml_str):


### PR DESCRIPTION
The following error is thrown with Python3: TypeError: a bytes-like object is required, not 'str'
ET.tostring(elem) is actually returning a bytestring, so we need the arguments of the replace() method to be bytes-encoded