### PR TITLE
codec: removed str-specific method-call that breaks python3 use

### DIFF
--- a/ucsmsdk/ucsxmlcodec.py
+++ b/ucsmsdk/ucsxmlcodec.py
@@ -37,7 +37,7 @@ def to_xml_str(elem):
         xml_str = to_xml_str(elem=xml_element)
     """
 
-    return ET.tostring(elem).replace("&#10;", "\n")
+    return ET.tostring(elem)
 
 
 def extract_root_elem(xml_str):


### PR DESCRIPTION
This replace() will break ciscos ucs_vlans Ansible module when ansible is using a python 3 interpreter:

The full traceback is:
  File "/tmp/ansible_m46512rk/ansible_modlib.zip/ansible/module_utils/remote_management/ucs.py", line 80, in                                       login
    handle.login()
  File "/home/rickard/virtualenv/lib/python3.6/site-packages/ucsmsdk/ucshandle.py", line 135, in login
    return self._login(auto_refresh, force, timeout=timeout)
  File "/home/rickard/virtualenv/lib/python3.6/site-packages/ucsmsdk/ucssession.py", line 599, in _login
    response = self.post_elem(elem, timeout=timeout)
  File "/home/rickard/virtualenv/lib/python3.6/site-packages/ucsmsdk/ucssession.py", line 312, in post_elem
    xml_str = xc.to_xml_str(elem)
  File "/home/rickard/virtualenv/lib/python3.6/site-packages/ucsmsdk/ucsxmlcodec.py", line 40, in to_xml_str
    return ET.tostring(elem).replace("&#10;", "\n")

I guess this means that ET.tostring() is going to return a bytes like object rather than a string when run by python3? If that's the case, you should probably convert that char somewhere else. If it's not, kindly let me know how I should solve my problem ;)

this change is covered by tests

Thank you