### PR TITLE
Childs in MO

### DIFF
--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -343,7 +343,7 @@ class UcsHandle(UcsSession):
 
         return class_id_dict
 
-    def query_dn(self, dn, hierarchy=False, need_response=False, timeout=None):
+    def query_dn(self, dn, hierarchy=False, need_response=False, timeout=None, child=False):
         """
         Finds an object using it's distinguished name.
 
@@ -381,7 +381,7 @@ class UcsHandle(UcsSession):
 
         elem = config_resolve_dns(cookie=self.cookie,
                                   in_dns=dn_set,
-                                  in_hierarchical=hierarchy)
+                                  in_hierarchical=child)
         response = self.post_elem(elem, timeout=timeout)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -401,7 +401,7 @@ class UcsHandle(UcsSession):
         return mo
 
     def query_classid(self, class_id=None, filter_str=None, hierarchy=False,
-                      need_response=False, timeout=None):
+                      need_response=False, timeout=None, child=False):
         """
         Finds an object using it's class id.
 
@@ -469,7 +469,7 @@ class UcsHandle(UcsSession):
         elem = config_resolve_class(cookie=self.cookie,
                                     class_id=meta_class_id,
                                     in_filter=in_filter,
-                                    in_hierarchical=hierarchy)
+                                    in_hierarchical=child)
         response = self.post_elem(elem, timeout=timeout)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -231,7 +231,7 @@ class UcsHandle(UcsSession):
 
         return auth_token
 
-    def query_dns(self, *dns):
+    def query_dns(self, *dns, child=False):
         """
         Queries multiple obects from the server based of a comma separated list
         of their distinguised names.
@@ -273,7 +273,8 @@ class UcsHandle(UcsSession):
             dn_set.child_add(dn_obj)
 
         elem = config_resolve_dns(cookie=self.cookie,
-                                  in_dns=dn_set)
+                                  in_dns=dn_set,
+                                  in_hierarchical=child)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)
@@ -283,7 +284,7 @@ class UcsHandle(UcsSession):
 
         return dn_dict
 
-    def query_classids(self, *class_ids):
+    def query_classids(self, *class_ids, child=False):
         """
         Queries multiple obects from the server based of a comma separated list
         of their class Ids.
@@ -333,7 +334,8 @@ class UcsHandle(UcsSession):
             class_id_set.child_add(class_id_obj)
 
         elem = config_resolve_classes(cookie=self.cookie,
-                                      in_ids=class_id_set)
+                                      in_ids=class_id_set,
+                                      in_hierarchical=child)
         response = self.post_elem(elem)
         if response.error_code != 0:
             raise UcsException(response.error_code, response.error_descr)

--- a/ucsmsdk/ucshandle.py
+++ b/ucsmsdk/ucshandle.py
@@ -373,6 +373,9 @@ class UcsHandle(UcsSession):
         from .ucsbasetype import DnSet, Dn
         from .ucsmethodfactory import config_resolve_dns
 
+        if hierarchy:
+            child = True
+        
         if not dn:
             raise ValueError("Provide dn.")
 
@@ -450,7 +453,8 @@ class UcsHandle(UcsSession):
 
         from .ucsfilter import generate_infilter
         from .ucsmethodfactory import config_resolve_class
-
+        if hierarchy:
+            child = True
         if not class_id:
             raise ValueError("Provide Parameter class_id")
 


### PR DESCRIPTION
Children from MO in query functions can only be obtainable if `hierarchy` is set to `True`. However, if it is `True`, the children are appended to `mo_list` and this list is returned to the query function making it difficult to establish a relationship in .query_dns and .query_classids. 

Without `child` option:
```python
topSystem = handle.query_classids('TopSystem')
print(topSystem)
print(topSystem[0].child)

""" 
output:
[<ucsmsdk.mometa.top.TopSystem.TopSystem object at 0x1116c5b00>]
[]
"""
```

Using `child`:
```python
topSystem = handle.query_classid('TopSystem', child=True)
print(topSystem)
print(topSystem[0].child)

"""
output:
[<ucsmsdk.mometa.top.TopSystem.TopSystem object at 0x10ca15588>]
[<ucsmsdk.mometa.trig.TrigMeta.TrigMeta object at 0x10ca154a8>, <ucsmsdk.mometa.extmgmt.ExtmgmtIfMonPolicy.ExtmgmtIfMonPolicy object at 0x10ca152b0>, <ucsmsdk.mometa.trig.TrigMeta.TrigMeta object at 0x10ca152e8>, <ucsmsdk.mometa.trig.TrigSched.TrigSched object at 0x10c4b9550>, <ucsmsdk.mometa.domain.DomainNetworkFeatureCont.DomainNetworkFeatureCont object at 0x10b765fd0>, <ucsmsdk.mometa.domain.DomainStorageFeatureCont.DomainStorageFeatureCont object at 0x10c2ddf60>, <ucsmsdk.mometa.domain.DomainServerFeatureCont.DomainServerFeatureCont object at 0x10b921eb8>, <ucsmsdk.mometa.trig.TrigMeta.TrigMeta object at 0x1099e2a90>, <ucsmsdk.mometa.trig.TrigLocalSched.TrigLocalSched object at 0x10caef278>, <ucsmsdk.mometa.trig.TrigMeta.TrigMeta object at 0x10caef2b0>, <ucsmsdk.mometa.sysdebug.SysdebugTechSupFileRepository.SysdebugTechSupFileRepository object at 0x10caeff98>, <ucsmsdk.mometa.mgmt.MgmtAccessPolicy.MgmtAccessPolicy object at 0x10caeffd0>, <ucsmsdk.mometa.trig.TrigMeta.TrigMeta object at 0x10cafb048>, <ucsmsdk.mometa.domain.DomainEnvironmentFeatureCont.DomainEnvironmentFeatureCont object at 0x10cafb860>, <ucsmsdk.mometa.firmware.FirmwareUpgradeInfo.FirmwareUpgradeInfo object at 0x10cb07470>, <ucsmsdk.mometa.trig.TrigSched.TrigSched object at 0x10cb07e48>, <ucsmsdk.mometa.mgmt.MgmtBackupPolicyConfig.MgmtBackupPolicyConfig object at 0x10cb07e80>, <ucsmsdk.mometa.trig.TrigSched.TrigSched object at 0x10a55cf98>, <ucsmsdk.mometa.trig.TrigSched.TrigSched object at 0x10cb11470>, <ucsmsdk.mometa.mgmt.MgmtIntAuthPolicy.MgmtIntAuthPolicy object at 0x10cb11e10>, <ucsmsdk.mometa.aaa.AaaSessionInfoTable.AaaSessionInfoTable object at 0x10cb11e48>, <ucsmsdk.mometa.mgmt.MgmtEntity.MgmtEntity object at 0x10cb11e80>, <ucsmsdk.mometa.mgmt.MgmtEntity.MgmtEntity object at 0x10cb11eb8>, <ucsmsdk.mometa.controller.ControllerHaController.ControllerHaController object at 0x10cb1c860>, <ucsmsdk.mometa.firmware.FirmwareCatalogue.FirmwareCatalogue object at 0x10cb276d8>, <ucsmsdk.mometa.top.TopInfoPolicy.TopInfoPolicy object at 0x10cb320b8>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10cb320f0>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10cc05550>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10d0ca1d0>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10d0fcda0>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10d132e48>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10d167fd0>, <ucsmsdk.mometa.compute.ComputeRackUnit.ComputeRackUnit object at 0x10d1ac198>, <ucsmsdk.mometa.aaa.AaaTacacsPlusEp.AaaTacacsPlusEp object at 0x10d1d69b0>, <ucsmsdk.mometa.extvmm.ExtvmmEp.ExtvmmEp object at 0x10cb32518>, <ucsmsdk.mometa.aaa.AaaRadiusEp.AaaRadiusEp object at 0x10d21abe0>, <ucsmsdk.mometa.aaa.AaaAuthRealm.AaaAuthRealm object at 0x10d24af28>, <ucsmsdk.mometa.firmware.FirmwareStatus.FirmwareStatus object at 0x10d2759e8>, <ucsmsdk.mometa.sysdebug.SysdebugCoreFileRepository.SysdebugCoreFileRepository object at 0x10d28ccc0>, <ucsmsdk.mometa.firmware.FirmwareSystem.FirmwareSystem object at 0x10d293dd8>, <ucsmsdk.mometa.equipment.EquipmentChassis.EquipmentChassis object at 0x10d2a24e0>, <ucsmsdk.mometa.equipment.EquipmentChassis.EquipmentChassis object at 0x10d323cf8>, <ucsmsdk.mometa.equipment.EquipmentChassis.EquipmentChassis object at 0x10d5189b0>, <ucsmsdk.mometa.equipment.EquipmentChassis.EquipmentChassis object at 0x10d5d6ac8>, <ucsmsdk.mometa.aaa.AaaUserEp.AaaUserEp object at 0x10d700630>, <ucsmsdk.mometa.aaa.AaaLdapEp.AaaLdapEp object at 0x10d2b95f8>, <ucsmsdk.mometa.feature.FeatureContextEp.FeatureContextEp object at 0x10d76a080>, <ucsmsdk.mometa.power.PowerEp.PowerEp object at 0x10d78b7b8>, <ucsmsdk.mometa.sysdebug.SysdebugEp.SysdebugEp object at 0x10d775cf8>, <ucsmsdk.mometa.network.NetworkElement.NetworkElement object at 0x10d78b7f0>, <ucsmsdk.mometa.network.NetworkElement.NetworkElement object at 0x10d8d9048>, <ucsmsdk.mometa.comm.CommSvcEp.CommSvcEp object at 0x10d9bbac8>, <ucsmsdk.mometa.pki.PkiEp.PkiEp object at 0x10da51518>, <ucsmsdk.mometa.version.VersionEp.VersionEp object at 0x10d7d0748>, <ucsmsdk.mometa.license.LicenseEp.LicenseEp object at 0x10da51550>, <ucsmsdk.mometa.equipment.EquipmentFex.EquipmentFex object at 0x10da6c908>, <ucsmsdk.mometa.equipment.EquipmentFex.EquipmentFex object at 0x10da6c940>, <ucsmsdk.mometa.mgmt.MgmtController.MgmtController object at 0x10dae0320>]
```