### PR TITLE
Improve regex expressions to avoid invalid escape sequence '\.' warings in python 3.12

### DIFF
--- a/ucsmsdk/ucscoremeta.py
+++ b/ucsmsdk/ucscoremeta.py
@@ -49,82 +49,82 @@ class UcsVersion(object):
         self.__spin = None
         self.__build = None
 
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,4})))\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   r"(?P<patch>(([0-9])|([1-9][0-9]{0,4})))\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
-                                   "(?P<patch>[a-z])\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
+                                   r"(?P<patch>[a-z])\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle spin builds "2.0(13aS1))"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
-                                   "(?P<patch>[a-z])"
-                                   "(?P<spin>S[1-9][0-9]{0,2})\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
+                                   r"(?P<patch>[a-z])"
+                                   r"(?P<spin>S[1-9][0-9]{0,2})\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle spin builds "3.0(1S10))"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
-                                   "(?P<spin>S[1-9][0-9]{0,2})\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
+                                   r"(?P<spin>S[1-9][0-9]{0,2})\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle de special builds "66.77(67.1582251418)"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,2})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,})))\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,2})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   r"(?P<patch>(([0-9])|([1-9][0-9]{0,})))\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle engineering builds "4.2(0.175a)"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,2})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<build>(([0-9])|([1-9][0-9]{0,})))"
-                                   "(?P<patch>[a-z])\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,2})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   r"(?P<build>(([0-9])|([1-9][0-9]{0,})))"
+                                   r"(?P<patch>[a-z])\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle spin builds "4.2(1.2021052301)"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<spin>\d{0,4}\d{0,2}\d{0,2}\d{0,2})\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   r"(?P<spin>\d{0,4}\d{0,2}\d{0,2}\d{0,2})\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return
 
         # handle patch spin builds "4.2(1a.2021052301)"
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
-                                   "(?P<patch>[a-z])\."
-                                   "(?P<spin>\d{0,4}\d{0,2}\d{0,2}\d{0,2})\)$")
+        match_pattern = re.compile(r"^(?P<major>[1-9][0-9]{0,2})\."
+                                   r"(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   r"(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
+                                   r"(?P<patch>[a-z])\."
+                                   r"(?P<spin>\d{0,4}\d{0,2}\d{0,2}\d{0,2})\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return

--- a/ucsmsdk/ucssession.py
+++ b/ucsmsdk/ucssession.py
@@ -359,7 +359,7 @@ class UcsSession(object):
 
         Args:
             url_suffix (str): suffix url to be appended to
-                    http\https://host:port/ to locate the file on the server
+                    http/https://host:port/ to locate the file on the server
             file_dir (str): The directory to download to
             file_name (str): The destination file name for the download
             progress (ucsgenutils.Progress): Class that has method to display progress
@@ -397,7 +397,7 @@ class UcsSession(object):
 
         Args:
             url_suffix (str): suffix url to be appended to
-                http\https://host:port/ to locate the file on the server
+                http/https://host:port/ to locate the file on the server
             source_dir (str): The directory to upload from
             file_name (str): The destination file name for the download
             progress (ucsgenutils.Progress): Class that has method to display progress
@@ -439,7 +439,7 @@ class UcsSession(object):
 
         Args:
             url_suffix (str): suffix url to be appended to
-                http\https://host:port/ to locate the file on the server
+                http/https://host:port/ to locate the file on the server
             source_dir (str): The directory to upload from
             file_name (str): The destination file name for the download
             progress (ucsgenutils.Progress): Class that has method to display progress


### PR DESCRIPTION
When using python 3.12 the following warnings appeared because of the regex expressions: `invalid escape sequence '\.'`
To avoid this warnings we should specify to python that the string is a regex expression putting an `r` before the expression. The following changes were applied:
- Regex expressions were corrected.
- Some comments were changed in order to avoid the warning.