### PR TITLE
Python 3.9 on test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.8]
+        version: [3.9]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The Python 3.8 is not available on the pipeline Vm.